### PR TITLE
chore: switch Renovate automerge to GitHub native PR automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,8 +34,7 @@
       "pinDigests": true,
       "dependencyDashboardApproval": false,
       "automerge": true,
-      "automergeType": "pr-comment",
-      "automergeComment": "automerge"
+      "automergeType": "pr"
     }
   ]
 }


### PR DESCRIPTION
`pr-comment` automerge type was a no-op without Mergify (or similar) configured to respond to the comment. Switching to `pr` uses GitHub's native automerge directly.

Also removes the now-unnecessary `automergeComment` field.