### PR TITLE
chore(flake): track nixos-raspberrypi nixos-unstable + update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1781023725,
-        "narHash": "sha256-Gt+qFANcrDRjl3xzidLYrAUQCd3808iuAsLwZbYYAEU=",
+        "lastModified": 1781627888,
+        "narHash": "sha256-5yHuAh9k7rT7rtf3uRaXkiUyYvQE9oaCgzhprLm2mr8=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "2ce9051767ee4d1a3c43b52ba327431783bfd463",
+        "rev": "6d3087eedff75a715b40c0e124ba15d2dd7bec28",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780894562,
-        "narHash": "sha256-c3430xwxwhHipl3jigUGMMBfpaMylDqytW/kdmB3ZGs=",
+        "lastModified": 1781152676,
+        "narHash": "sha256-RxWs5ND31KzTG7wvMM+PMfUjyNpmIEr999lqNARaM5o=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "24fed06cac83bcc44ac8efbb57cab1a82fa0bedc",
+        "rev": "ff8702b4de27f72b4c78573dfb89ec74e36abdf1",
         "type": "github"
       },
       "original": {
@@ -68,11 +68,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781131193,
-        "narHash": "sha256-hO2hUFyLgu32eA+901lCtNSK+AsQfl5+3KBNoxkteCA=",
+        "lastModified": 1782258299,
+        "narHash": "sha256-C4YBp1cT9wYwXAUgaVwQnl+jR0JZlP0nm7EfSDZj2Vg=",
         "owner": "bcrescimanno",
         "repo": "dotfiles",
-        "rev": "37d8e2f95caf0d3b365a620adbafcbaf375f5630",
+        "rev": "24d67c78311432c254eefb52c26b8400429c1e49",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781129616,
-        "narHash": "sha256-Hl0Pz/QIKpePSU7SdK3BMe5VNmUhFvfWyg57GyawxzE=",
+        "lastModified": 1782233665,
+        "narHash": "sha256-h/xOtrByoA/Ak1lWHn0O1lVZz4qWYbwOSLQ8YSwQO0I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7dbd305f8b81050f223f00bcfbc8a6b74e048806",
+        "rev": "062581938b4a378a82dfbb294b494808157153a1",
         "type": "github"
       },
       "original": {
@@ -168,27 +168,27 @@
         ]
       },
       "locked": {
-        "lastModified": 1779023229,
-        "narHash": "sha256-MInilg7B/06c34SwOuGSBho4l0H1EZcmvxTkSWCs5pE=",
+        "lastModified": 1782001598,
+        "narHash": "sha256-yyYvgxcHVPWfAijykwL3DsZ5XsuZ1mt/124e04VdKdA=",
         "owner": "nvmd",
         "repo": "nixos-raspberrypi",
-        "rev": "06c6e3513e1ee64b651913193fc6ac38aa4963f5",
+        "rev": "69c55208b0b9757feca71fc596f912a6355c8094",
         "type": "github"
       },
       "original": {
         "owner": "nvmd",
-        "ref": "main",
+        "ref": "nixos-unstable",
         "repo": "nixos-raspberrypi",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780930886,
-        "narHash": "sha256-rppURzHviaQN131F+nLiLdGfcb0uCd9gGP0E5+iw9MI=",
+        "lastModified": 1782118813,
+        "narHash": "sha256-BnbXO5s5EhV89lLXMAGCzPdEN5a6vNqvMk71obeTEUw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8c3cede7ddc26bd659d2d383b5610efbd2c7a16e",
+        "rev": "b3c092d3c36d91e2f61f3dfb39a159f180a56659",
         "type": "github"
       },
       "original": {
@@ -216,11 +216,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780547341,
-        "narHash": "sha256-Gq8KNx5A7hBB3uGJaj6eQfLDIz5YdLu92gqBcvHvoUo=",
+        "lastModified": 1782165805,
+        "narHash": "sha256-478kKQBvK6SYTOdN2h9jhKJv94nbXRbFMfuL1WshErg=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "9ed65852b6257fbeae4355bc24ecfea307ca759a",
+        "rev": "56b24064fdcaedca53553b1a6d607fd23b613a24",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,13 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nixos-raspberrypi.url = "github:nvmd/nixos-raspberrypi/main";
+    # Track `nixos-unstable` (not `main`): we run nixpkgs-unstable, and this is
+    # nixos-raspberrypi's companion branch for that channel, so the two move
+    # together. The stable `main` branch lags — it froze at 2026-05-17 with an
+    # unguarded `boot.loader.kernelFile = …stdenv.hostPlatform.linux-kernel.target`,
+    # which broke once nixpkgs 26.11 removed that attribute. nixos-unstable carries
+    # the version-guarded fix.
+    nixos-raspberrypi.url = "github:nvmd/nixos-raspberrypi/nixos-unstable";
     nixos-raspberrypi.inputs.nixpkgs.follows = "nixpkgs";
     disko.url = "github:nix-community/disko";
     disko.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
## What

Retry of the flake/lock-file maintenance that #327 attempted and that was reverted in `b968c60`, plus a branch-tracking fix for `nixos-raspberrypi`.

## Why it broke before

nixpkgs `26.11` removed `stdenv.hostPlatform.linux-kernel`. The `nixos-raspberrypi` **`main`** branch still referenced it unguarded (`boot.loader.kernelFile = pkgs.stdenv.hostPlatform.linux-kernel.target`), so **all aarch64 Pi closures failed to evaluate** (`error: attribute 'linux-kernel' missing`). orthanc/x86_64 was unaffected. That's why #327 had to be reverted.

## Root cause + fix

We pin **nixpkgs-unstable**, but tracked nixos-raspberrypi's **`main`** (stable) branch — which lags nixpkgs-unstable and froze at 2026-05-17. nvmd maintains a dedicated **`nixos-unstable`** branch that tracks the nixpkgs-unstable channel and carries the version-guarded `kernelFile` fix:

```nix
boot.loader.kernelFile =
  if lib.versionAtLeast lib.trivial.release "26.11"
  then config.boot.kernelPackages.kernel.target   # 26.11+
  else pkgs.stdenv.hostPlatform.linux-kernel.target;
```

This PR switches `nixos-raspberrypi.url` from `…/main` → `…/nixos-unstable` so the two inputs move together, preventing this class of breakage going forward.

## Inputs refreshed

`nixpkgs` → `b3c092d3c` (26.11) · `nixos-raspberrypi` → `69c55208b` (nixos-unstable) · plus `deploy-rs`, `disko`, `dotfiles`, `home-manager`, `sops-nix`.

## Verified locally

- `nix flake check --no-build` passes
- All four hosts (pirateship, rivendell, mirkwood, orthanc) evaluate `…system.build.toplevel` on 26.11 with **no** linux-kernel error

## Merge gate

Wait for the **aarch64 closure job** in `Pre-build flake update` to go green before merging (it both proves the Pi build and warms attic). Then deploy orthanc first, then the Pis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)