### PR TITLE
fix(otbr): fully-qualify image to avoid short-name DNS lookup race

### DIFF
--- a/modules/homeassistant.nix
+++ b/modules/homeassistant.nix
@@ -88,7 +88,11 @@
     #   With those modules loaded, iptables-legacy inside the container can
     #   coexist with the host's nftables firewall.
     otbr = {
-      image = "openthread/otbr:latest@sha256:b8e365e1847a829c7512de41c8832ee1e7c4f1b61320efd299ae5b2b9d5238a3";
+      # Fully qualified (docker.io/) so podman does NOT treat this as an
+      # unqualified short name — that triggers a registry DNS lookup at container
+      # start which races blocky's restart during nixos-rebuild switch and fails
+      # activation (cost a rivendell rollback on 2026-06-24). See note below.
+      image = "docker.io/openthread/otbr:latest@sha256:b8e365e1847a829c7512de41c8832ee1e7c4f1b61320efd299ae5b2b9d5238a3";
       autoStart = true;
       cmd = [
         "--radio-url" "spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=460800"
@@ -127,10 +131,11 @@
     "d /var/lib/otbr/data 0755 root root -"
   ];
 
-  # Podman treats "openthread/otbr" as an unqualified image name and performs
-  # a registry DNS lookup even with --pull=missing. During nixos-rebuild switch,
-  # blocky may be momentarily stopped, causing the lookup to fail and the
-  # service to be reported as failed. Ordering after blocky ensures DNS is up.
+  # otbr's image is now fully qualified (docker.io/…, see above) so podman no
+  # longer does an unqualified short-name registry DNS lookup at container start —
+  # that lookup races blocky's restart during nixos-rebuild switch and fails
+  # activation. The `after = blocky.service` ordering is kept as belt-and-suspenders
+  # (blocky should be up before otbr regardless).
   systemd.services.podman-otbr = {
     after = [ "blocky.service" ];
   };


### PR DESCRIPTION
## Problem

During the 26.11 flake-update deploy (2026-06-24), **rivendell's deploy failed and deploy-rs auto-rolled-back**:

```
Failed to start podman-otbr.service
⚠️ De-activating due to error → rolled back
```

`podman` treats `openthread/otbr` as an **unqualified short name**, so it performs a registry DNS lookup at container start — even pinned by digest. During `nixos-rebuild switch`, blocky (DNS) restarts, so the lookup can fail → `podman-otbr` fails → activation fails → rollback. The other three hosts have no otbr and deployed cleanly. (CLAUDE.md already documented this race; the `after = blocky.service` ordering wasn't sufficient.)

## Fix

Fully-qualify the image as `docker.io/openthread/otbr:…` so podman resolves it directly with no short-name registry search. Kept the `after = blocky.service` ordering as a backstop, and updated the inline comments.

## Validation

Already deployed to rivendell from this branch: activation succeeded, deployment confirmed, `podman-otbr` active, no rollback, generation state reconciled to `26.11.20260622`. This PR just lands the same change on `main` (rivendell currently runs it ahead of merge).

> Note for review: Renovate's digest pin (`@sha256:…`) is unchanged; only the registry prefix was added. Confirm Renovate's docker digest manager still matches the now-qualified name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)