### PR TITLE
feat(recyclarr): single combined-resolution quality profile per app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ All arr containers share gluetun's network namespace (`--network=container:gluet
 - **qbittorrent**: torrent client (port 9091 via gluetun); image `lscr.io/linuxserver/qbittorrent:libtorrentv1`; `dl.theshire.io` via Caddy
 - **sabnzbd**: Usenet client (port 8080 via gluetun)
 - **radarr/sonarr/prowlarr/lidarr**: media managers (ports 7878/8989/9696/8686 via gluetun)
-- **recyclarr**: syncs TRaSH quality profiles to radarr/sonarr; API keys via sops secret `recyclarr_env`
+- **recyclarr**: native NixOS service (not a container), daily, syncs TRaSH quality profiles + custom formats to radarr/sonarr; API keys via sops secrets `recyclarr_radarr_api_key`/`recyclarr_sonarr_api_key`. Exactly **one guide "(Combined)" profile per app** — Radarr `Remux 2160p (Combined)`, Sonarr `WEB-2160p (Combined)`. See the comment block in `arr-stack.nix` for why single-resolution profiles were dropped.
 - **jellyfin**: media server (port 8096, direct — not through VPN)
 - **navidrome**: music streaming server (port 4533, native NixOS service — not a container, not through VPN); declared in `modules/navidrome.nix`
 
@@ -149,7 +149,7 @@ Secrets use `sops-nix` with age encryption. Rendered at runtime to `/run/secrets
 **pirateship** (`secrets/pirateship.yaml`):
 - `vpn_env` — WireGuard credentials for gluetun
 - `qbt_credentials` — `QBT_USERNAME`/`QBT_PASSWORD` (used by preStart to generate PBKDF2 hash and by qbittorrent-port-sync)
-- `recyclarr_env` — `SONARR_API_KEY`/`RADARR_API_KEY`
+- `recyclarr_radarr_api_key` / `recyclarr_sonarr_api_key` — API keys for the recyclarr sync
 
 **rivendell** (`secrets/rivendell.yaml`):
 - `caddy_cloudflare_env` — `CLOUDFLARE_API_TOKEN` for DNS-01 ACME

--- a/modules/arr-stack.nix
+++ b/modules/arr-stack.nix
@@ -544,6 +544,26 @@ PYEOF
   # the pirateship host loopback (ports 7878/8989), so it does not need to be
   # behind the VPN. Config is now fully declarative; API keys are injected via
   # systemd LoadCredential from sops (genJqSecretsReplacement resolves _secret).
+  #
+  # One "(Combined)" guide profile per app, not a stack of per-resolution ones.
+  # The single-resolution TRaSH profiles (e.g. "Remux + WEB 2160p") allow ONLY
+  # their own tier, so a title with no 2160p release available never gets
+  # grabbed at all. The combined profiles span both resolutions in one ordered
+  # cascade, and because Radarr/Sonarr's DownloadDecisionComparer ranks by
+  # quality-profile index BEFORE custom format score, that ordering is what
+  # actually decides grabs — CF scores only break ties within a tier:
+  #
+  #   Radarr  Remux-2160p > Bluray-2160p > WEB 2160p > Remux-1080p
+  #             > Bluray-1080p > WEB 1080p        (nothing below 1080p allowed)
+  #   Sonarr  WEB 2160p > WEB 1080p     (WEB-only: 4K TV remuxes are rare on
+  #                                      indexers and ruinously large)
+  #
+  # Both profiles ship upgradeAllowed=true with cutoff at their top tier and
+  # cutoffFormatScore=10000, so a title grabbed at a lower tier stays eligible
+  # to be replaced when a higher-tier release appears. That replacement only
+  # fires when the release shows up in an RSS sync — there is no scheduled
+  # Cutoff Unmet search, so backfilling an existing library needs a one-off
+  # manual "Cutoff Unmet" search from the UI.
   sops.secrets.recyclarr_sonarr_api_key = {};
   sops.secrets.recyclarr_radarr_api_key = {};
 
@@ -557,8 +577,7 @@ PYEOF
         delete_old_custom_formats = true;
         quality_definition.type = "series";
         quality_profiles = [
-          { trash_id = "72dae194fc92bf828f32cde7744e51a1"; reset_unmatched_scores.enabled = true; } # WEB-1080p
-          { trash_id = "d1498e7d189fbe6c7110ceaabb7473e6"; reset_unmatched_scores.enabled = true; } # WEB-2160p
+          { trash_id = "c4cadd6b35b95f62c3d47a408e53e2f7"; reset_unmatched_scores.enabled = true; } # WEB-2160p (Combined)
         ];
       };
       radarr.radarr-main = {
@@ -567,11 +586,7 @@ PYEOF
         delete_old_custom_formats = true;
         quality_definition.type = "movie";
         quality_profiles = [
-          { trash_id = "fd161a61e3ab826d3a22d53f935696dd"; reset_unmatched_scores.enabled = true; } # Remux + WEB 2160p
-          { trash_id = "64fb5f9858489bdac2af690e27c8f42f"; reset_unmatched_scores.enabled = true; } # UHD Bluray + WEB
-          { trash_id = "e91c9adaca0231493f4af0d571b907f9"; reset_unmatched_scores.enabled = true; } # [SQP] SQP-1 WEB (2160p)
-          { trash_id = "9ca12ea80aa55ef916e3751f4b874151"; reset_unmatched_scores.enabled = true; } # Remux + WEB 1080p
-          { trash_id = "d1d67249d3890e49bc12e275d989a7e9"; reset_unmatched_scores.enabled = true; } # HD Bluray + WEB
+          { trash_id = "d1d310673359205736b4b84acd5ea8c8"; reset_unmatched_scores.enabled = true; } # Remux 2160p (Combined)
         ];
       };
     };


### PR DESCRIPTION
The per-resolution TRaSH profiles allow only their own tier, so a title
with no release at that tier never gets grabbed at all — "Remux + WEB
2160p" doesn't even permit Bluray-2160p, let alone any 1080p fallback.

Replace the five Radarr profiles and two Sonarr profiles with one guide
"(Combined)" profile each, which spans both resolutions in a single
ordered cascade. Quality-profile index is compared before custom format
score in DownloadDecisionComparer, so that ordering decides grabs.

Radarr "Remux 2160p (Combined)":
  Remux-2160p > Bluray-2160p > WEB 2160p > Remux-1080p > Bluray-1080p
  > WEB 1080p; nothing below 1080p allowed.
Sonarr "WEB-2160p (Combined)":
  WEB 2160p > WEB 1080p. WEB-only rather than the remux variant — 4K TV
  remuxes are rare on indexers and ruinously large.

Both carry upgradeAllowed with cutoff at the top tier and
cutoffFormatScore 10000, so a lower-tier grab stays eligible for
replacement when a better release appears via RSS.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
