### PR TITLE
fix(jellyfin): stop rewriting the notification on every sync

### DIFF
--- a/modules/jellyfin-notify-sync.py
+++ b/modules/jellyfin-notify-sync.py
@@ -105,14 +105,22 @@ def sync_arr(app):
         return {f["name"]: f.get("value") for f in n.get("fields") or []}
 
     if cur is None:
-        # No forceSave: the arr tests the connection on save, so a success here
-        # is proof the notification actually reaches Jellyfin.
         http(base + "/notification", "POST", hdr, json.dumps(body).encode())
         changed.append("%-7s created notification %r" % (app["app"], body["name"]))
         return
 
     cm, wm = field_map(cur), field_map(body)
-    drift = [k for k, v in wm.items() if cm.get(k) != v]
+    # Radarr and Sonarr return secret fields as '********' on read, so a naive
+    # comparison against the real value always reports drift and rewrites the
+    # notification on every run. Treat the mask as "opaque, assume unchanged".
+    #
+    # Consequence: rotating jellyfin_api_key is NOT picked up automatically —
+    # delete the notification (or change any other field) to force a rewrite.
+    # Do not "fix" this by testing the connection instead: POST /notification/test
+    # returns 200 even with a deliberately wrong API key, because the arr does
+    # not check Jellyfin's response. It proves reachability, nothing more.
+    drift = [k for k, v in wm.items()
+             if cm.get(k) != v and cm.get(k) != "********"]
     trig = [k for k in body if k.startswith("on") and isinstance(body[k], bool)
             and cur.get(k) != body[k]]
     if drift or trig:

--- a/modules/jellyfin-notify.nix
+++ b/modules/jellyfin-notify.nix
@@ -93,9 +93,15 @@ in
     serviceConfig = {
       Type = "oneshot";
       RemainAfterExit = true;
-      # Radarr/Sonarr validate the connection when saving a notification, so a
-      # failure here is a real signal that the push does not work. Retry rather
-      # than latch: after a gluetun restart the netns takes a while to settle.
+      # Retry rather than latch: after a gluetun restart the netns takes a
+      # while to settle before radarr/sonarr answer.
+      #
+      # Note the arr connection test is weaker than it looks — POST
+      # /notification/test returns 200 even with a deliberately wrong API key,
+      # since the arr does not inspect Jellyfin's response. Real end-to-end
+      # proof is a "will be refreshed" line in Jellyfin's log on orthanc
+      # (/var/lib/jellyfin/log/log_*.log) after an import, with no accompanying
+      # "Invalid token".
       Restart = "on-failure";
       RestartSec = "60s";
       ExecStart = lib.concatStringsSep " " [


### PR DESCRIPTION
Radarr and Sonarr return secret fields as '********' on read, so comparing
the stored apiKey against the real value always reported drift and issued a
PUT on every run. Both apps were rewriting their notification each time the
oneshot fired.

Treat the mask as opaque and skip it in drift detection. Consequence, now
documented in the script: rotating jellyfin_api_key is not picked up
automatically and needs the notification deleted to force a rewrite.

Do not replace this with a connection test. POST /api/v3/notification/test
returns 200 even with a deliberately wrong API key -- verified against both
apps -- because the arr does not inspect Jellyfin's response. Jellyfin logs
"Invalid token" while the arr reports success, so the test proves TCP
reachability and nothing else. Real end-to-end proof is a "will be
refreshed" line in Jellyfin's log after an import.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
