### PR TITLE
feat(music): keep Lidarr, Navidrome and Music Assistant in sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ SOPS_AGE_KEY_FILE=~/.config/sops/age/keys.txt sops secrets/mirkwood.yaml
 - `modules/homeassistant.nix` — Home Assistant + Matter Server containers on rivendell (host networking for mDNS); both containers use `--privileged` so USB dongles (Zigbee, Thread) are auto-accessible
 - `modules/homepage.nix` — Homepage dashboard as native NixOS service via `services.homepage-dashboard` (mirkwood, port 3000)
 - `modules/monitoring.nix` — Glances system monitor as native NixOS service (all three hosts, port 61208)
+- `modules/music-sync.nix` — keeps Lidarr, Navidrome and Music Assistant in step with `/var/lib/media/music`. **Every filesystem watcher on that share is inert** (NFS + a remote writer, same root cause as Jellyfin/Bazarr), so `music-sync.timer` polls the ~278 *directory* mtimes every 2 min (0.2–1s), debounces one interval so a half-copied album is never scanned, then issues a targeted `RefreshArtist` per changed artist plus `music/sync` to Music Assistant. `music-library-audit.timer` runs daily: it repoints Lidarr artists whose folder drifted from disk and ntfy's about folders needing a manual Library Import. Runs on the pirateship **host**, not in gluetun's netns — see the module comment.
 - `modules/ntfy.nix` — ntfy push notification server container on rivendell (port 2586 LAN, proxied via Caddy)
 - `modules/nut.nix` — Network UPS Tools monitoring Tripp Lite SMC15002URM via USB (rivendell); exposes port 3493 for Home Assistant
 
@@ -151,6 +152,8 @@ Secrets use `sops-nix` with age encryption. Rendered at runtime to `/run/secrets
 - `vpn_env` — WireGuard credentials for gluetun
 - `qbt_credentials` — `QBT_USERNAME`/`QBT_PASSWORD` (used by preStart to generate PBKDF2 hash and by qbittorrent-port-sync)
 - `recyclarr_radarr_api_key` / `recyclarr_sonarr_api_key` — API keys for the recyclarr sync
+- `jellyfin_api_key` — used by `jellyfin-notify-sync` to configure the library-update push in radarr/sonarr/bazarr
+- `ma_token` — long-lived Music Assistant API token, used by `music-sync` to trigger `music/sync` on rivendell
 
 **rivendell** (`secrets/rivendell.yaml`):
 - `caddy_cloudflare_env` — `CLOUDFLARE_API_TOKEN` for DNS-01 ACME

--- a/flake.nix
+++ b/flake.nix
@@ -160,6 +160,7 @@
           ./modules/jellyfin-notify.nix
           ./modules/lidarr-formats.nix
           ./modules/monitoring.nix
+          ./modules/music-sync.nix
           ./modules/navidrome.nix
         ];
         specialArgs = { inherit inputs nixos-raspberrypi r2AccountId brianSshKey; };

--- a/modules/music-assistant.nix
+++ b/modules/music-assistant.nix
@@ -30,7 +30,15 @@
 {
   services.music-assistant = {
     enable = true;
-    providers = [ "airplay" "chromecast" "sendspin" "dlna" ];
+    # "sonos" is here because the Sonos provider is enabled in MA's own
+    # settings.json (MA turns it on as part of default_providers_setup). Without
+    # it declared, MA cannot import the module and logs
+    # "Failed to load provider module for sonos" plus a recursion traceback on
+    # every single startup. Declaring it installs the dependency and silences
+    # that; it is inert if there are no Sonos devices on the network. The
+    # alternative is disabling the provider in the MA UI, which puts the fix
+    # outside Nix.
+    providers = [ "airplay" "chromecast" "sendspin" "dlna" "sonos" ];
   };
 
   networking.firewall.allowedTCPPorts = [ 8095 8097 7000 8927 ];

--- a/modules/music-assistant.nix
+++ b/modules/music-assistant.nix
@@ -24,21 +24,34 @@
 # MA sends M-SEARCH to 239.255.255.250 (multicast), but multicast UDP doesn't
 # create conntrack entries, so the unicast SSDP replies from players appear as
 # NEW packets and get dropped. Trusting eth0 (the LAN interface) unblocks them.
+# That blanket trust also covers the mDNS (UDP 5353) discovery the wiim and sonos
+# providers rely on, so neither needs a port added.
 
 { config, pkgs, lib, ... }:
 
 {
   services.music-assistant = {
     enable = true;
-    # "sonos" is here because the Sonos provider is enabled in MA's own
-    # settings.json (MA turns it on as part of default_providers_setup). Without
-    # it declared, MA cannot import the module and logs
+    # Adding a name here does not "enable" a provider -- it installs that
+    # provider's Python dependencies. nixpkgs patches out MA's pip-install path
+    # (dont-install-deps.patch) and replaces it with a hard error, so a provider
+    # MA has enabled in its own settings.json but which is missing from this list
+    # fails to import on every startup. That patch also drops MA's `==` version
+    # check, which is why nixpkgs shipping wiim 0.1.5 against MA's pinned
+    # wiim==0.1.4 is harmless.
+    #
+    # "sonos": MA enables this itself via default_providers_setup, and there are
+    # two Sonos devices on the LAN (a Beam and one more, both visible as
+    # uuid:RINCON_* DLNA renderers). Without it declared MA logged
     # "Failed to load provider module for sonos" plus a recursion traceback on
-    # every single startup. Declaring it installs the dependency and silences
-    # that; it is inert if there are no Sonos devices on the network. The
-    # alternative is disabling the provider in the MA UI, which puts the fix
-    # outside Nix.
-    providers = [ "airplay" "chromecast" "sendspin" "dlna" "sonos" ];
+    # every single startup.
+    #
+    # "wiim": native LinkPlay support, discovered over mDNS (_linkplay._tcp).
+    # Covers the WiiM Pro ("Stereo", 10.0.1.179) and WiiM Amp Pro ("Office
+    # Music", 10.0.1.20), both of which previously only arrived as generic DLNA
+    # renderers. "dlna" deliberately stays -- the TVs (Playroom TV, Television,
+    # Samsung Frame 50) have no native provider and would disappear without it.
+    providers = [ "airplay" "chromecast" "sendspin" "dlna" "sonos" "wiim" ];
   };
 
   networking.firewall.allowedTCPPorts = [ 8095 8097 7000 8927 ];

--- a/modules/music-library-audit.py
+++ b/modules/music-library-audit.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Repair and report Lidarr artist folders that have drifted from the disk.
+
+Lidarr derives an artist's folder from its canonical MusicBrainz name
+(artistFolderFormat = {Artist Name}, with illegal characters substituted), which
+is frequently not the folder a CD rip was copied into. When they disagree the
+artist keeps working -- its track files were attached once by a Library Import --
+but `artist.path` points at a directory that does not exist, and every subsequent
+scan silently skips it. The only trace is a missing line in the log: a healthy
+artist logs "Scanning /media/music/X" before "Completed scanning disk for X".
+
+That is a permanent, silent hole: new albums ripped into that folder are never
+seen again. 11 of 99 artists were in this state when this was written, e.g.
+artist "AC/DC" pointing at /media/music/AC+DC while the files live in ACDC/.
+
+So this does two things:
+
+  * Repairs what it can prove. If an artist's path is missing but all of its
+    track files sit under one folder, that folder is the artist's real home;
+    repoint `path` there with moveFiles=false. No data moves and the operation
+    is idempotent.
+
+  * Reports what it cannot. Folders that belong to no artist need a Library
+    Import, because Lidarr has no way to guess the MusicBrainz artist by itself.
+    Artists with a missing path AND no track files cannot be inferred either --
+    a same-name suggestion is offered but never applied, since attaching the
+    wrong folder to an artist is far worse than leaving it broken.
+"""
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+SPEC = sys.argv[1]
+
+with open(SPEC) as fh:
+    spec = json.load(fh)
+
+ROOT = spec["musicRoot"]
+LIDARR = spec["lidarr"]
+LROOT = LIDARR["lidarrRoot"]
+
+changed, warnings = [], []
+
+
+def http(url, method="GET", headers=None, data=None, timeout=60):
+    req = urllib.request.Request(url, method=method, data=data, headers=headers or {})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        raw = r.read()
+    return json.loads(raw) if raw and raw[:1] in b"[{" else raw
+
+
+def to_host(p):
+    """Translate a Lidarr path to the host's view of the same file."""
+    rel = os.path.relpath(p.rstrip("/"), LROOT)
+    return os.path.join(ROOT, rel)
+
+
+def norm(s):
+    """Loose key for *suggesting* a match. Never used to apply one."""
+    return re.sub(r"[^a-z0-9]", "", s.lower())
+
+
+with open(LIDARR["configPath"]) as fh:
+    key = re.search(r"<ApiKey>([^<]+)</ApiKey>", fh.read()).group(1)
+base = "http://127.0.0.1:%d/api/v1" % LIDARR["port"]
+hdr = {"X-Api-Key": key, "Content-Type": "application/json"}
+
+artists = http(base + "/artist", headers=hdr)
+disk = sorted(d.name for d in os.scandir(ROOT) if d.is_dir(follow_symlinks=False))
+
+
+# ------------------------------------------------------- repair missing paths
+broken = [a for a in artists if not os.path.isdir(to_host(a["path"]))]
+unresolved = []
+repointed = []
+
+for a in broken:
+    files = http(base + "/trackfile?" + urllib.parse.urlencode({"artistId": a["id"]}),
+                 headers=hdr)
+    # The artist folder is whatever sits directly under the root, so take the
+    # first path component rather than computing a common prefix -- that keeps a
+    # stray file elsewhere in the tree from widening the answer to the root.
+    tops = {os.path.relpath(f["path"], LROOT).split(os.sep, 1)[0] for f in files}
+    tops = {t for t in tops if t not in (".", "..", os.sep)}
+
+    if len(tops) != 1:
+        unresolved.append((a, sorted(tops)))
+        continue
+
+    folder = tops.pop()
+    want = os.path.join(LROOT, folder)
+    body = dict(a)
+    body["path"] = want
+    # moveFiles=false: the files are already where they belong. This only
+    # corrects Lidarr's idea of where that is.
+    http("%s/artist/%d?moveFiles=false" % (base, a["id"]), "PUT", hdr,
+         json.dumps(body).encode())
+    repointed.append(folder)
+    changed.append("repointed %r: %s -> %s" % (a["artistName"], a["path"], want))
+
+
+# --------------------------------------------------------------- report gaps
+owned = set(repointed)
+for a in artists:
+    p = a["path"].rstrip("/")
+    if os.path.dirname(p) == LROOT:
+        owned.add(os.path.basename(p))
+
+orphan_dirs = [d for d in disk if d not in owned]
+if orphan_dirs:
+    warnings.append("%d folder(s) belong to no Lidarr artist (need Library Import): %s"
+                    % (len(orphan_dirs), ", ".join(orphan_dirs)))
+
+by_norm = {}
+for d in orphan_dirs:
+    by_norm.setdefault(norm(d), []).append(d)
+
+for a, tops in unresolved:
+    hint = by_norm.get(norm(a["artistName"]), [])
+    detail = "%r has no folder and %s" % (
+        a["artistName"],
+        "no track files to infer one from" if not tops
+        else "track files spread over %s" % ", ".join(tops),
+    )
+    if len(hint) == 1:
+        detail += " -- did you mean %r? (not applied automatically)" % hint[0]
+    warnings.append(detail)
+
+
+# ---------------------------------------------------------------------- output
+for line in changed:
+    print(line)
+for line in warnings:
+    print("WARN " + line)
+if not changed and not warnings:
+    print("up to date: %d artists, %d folders, all paths resolve" % (len(artists), len(disk)))
+
+if warnings and spec.get("ntfyUrl"):
+    body = "%s\n\n%s" % (spec["host"], "\n\n".join(warnings))
+    if changed:
+        body += "\n\nAuto-repaired:\n" + "\n".join(changed)
+    try:
+        http(spec["ntfyUrl"], "POST",
+             {"Title": "Lidarr music library needs attention",
+              "Priority": "3", "Tags": "musical_note"},
+             body.encode())
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        # Losing the notification should not fail the unit -- the findings are
+        # already in the journal, and OnFailure would then alert about the
+        # alerting rather than about the library.
+        print("WARN could not reach ntfy: %s" % e, file=sys.stderr)

--- a/modules/music-sync.nix
+++ b/modules/music-sync.nix
@@ -1,0 +1,156 @@
+# modules/music-sync.nix — keep Lidarr, Navidrome and Music Assistant in step
+#
+# Four services read the same erebor NFS share at /var/lib/media/music, and every
+# filesystem watcher on it is inert. inotify does not deliver events for writes
+# made by a different NFS client, and the writers are always elsewhere: an arr
+# container on pirateship, or a CD rip copied straight onto the NAS. Same root
+# cause already documented for Jellyfin in modules/jellyfin-notify.nix and for
+# Bazarr's realtime monitor.
+#
+# So each service fell back to its own schedule, and the real numbers were much
+# worse than the configured ones looked:
+#
+#   Navidrome         Scanner.Schedule "1h"        -- honoured; watcher never fired.
+#                     24h of journal showed scans only on the hour, despite Lidarr
+#                     importing at 09:11, 10:06, 10:44 and 13:40 that day.
+#   Music Assistant   provider_sync_interval_* 30  -- DEAD CONFIG. Nothing in 2.9.9
+#                     reads those keys; the real schedule is a hardcoded
+#                     TaskSchedule.hourly(every=12) in models/music_provider.py.
+#                     The library synced twice a day.
+#   Lidarr            RescanFolders daily          -- and ~6 min per run, since it
+#                     walks all 99 artist folders.
+#
+# music-sync.timer replaces that with detection cheap enough to run every two
+# minutes: stat the ~278 directories (0.09s warm, 1.28s cold) and compare mtimes.
+# A change must persist for one full interval before anything is triggered, so a
+# half-copied album or an in-flight import is never scanned mid-write. When the
+# tree does settle, only the artists that actually changed are refreshed.
+#
+# Placement matters: this runs on the pirateship HOST, not inside gluetun's
+# network namespace. It reaches Lidarr on 127.0.0.1:8686 (gluetun publishes it to
+# the host) and Music Assistant on rivendell directly. Driving it from a Lidarr
+# custom script instead would need rivendell added to FIREWALL_OUTBOUND_SUBNETS,
+# and rivendell is a blocky DNS host — see the gluetun-lan-exception rationale in
+# arr-stack.nix for why that list stays at orthanc's /32.
+#
+# Navidrome is not pushed to. Its quick scan is already an mtime walk that
+# finishes in under a second, so it only needed a shorter schedule (see
+# modules/navidrome.nix). 0.63.2 does not advertise the apiKeyAuthentication
+# OpenSubsonic extension, so a push would mean storing a user's password in sops
+# to save two or three minutes of latency.
+#
+# music-library-audit.timer is the daily counterpart: it repairs Lidarr artists
+# whose folder has drifted from the disk and nags about folders that need a
+# manual Library Import. See music-library-audit.py for why that class of bug is
+# invisible without it.
+#
+# Neither unit belongs in homelab.postUpgradeCheck.services: that check asserts
+# `systemctl is-active` == active, which is false for a timer-driven oneshot
+# between runs. They alert through OnFailure instead.
+
+{ config, pkgs, lib, ... }:
+
+let
+  ntfyUrl  = "http://10.0.1.9:2586/homelab";
+  host     = config.networking.hostName;
+  stateDir = "/var/lib/music-sync";
+
+  musicRoot = "/var/lib/media/music";
+
+  # Lidarr's view of the same share: the container bind-mounts /var/lib/media at
+  # /media, so its artist paths read /media/music/<Artist>.
+  lidarr = {
+    port = 8686;
+    lidarrRoot = "/media/music";
+    # Read from Lidarr's own config at runtime rather than sops: Lidarr generates
+    # it, it changes if the config volume is reset, and it is already on disk.
+    # Same reasoning as modules/lidarr-formats.nix.
+    configPath = "/var/lib/lidarr/config/config.xml";
+  };
+
+  syncSpec = pkgs.writeText "music-sync.json" (builtins.toJSON {
+    inherit musicRoot lidarr;
+    statePath = "${stateDir}/state.json";
+    musicAssistant = {
+      url = "http://10.0.1.9:8095";          # rivendell
+      tokenFile = config.sops.secrets.ma_token.path;
+    };
+  });
+
+  auditSpec = pkgs.writeText "music-library-audit.json" (builtins.toJSON {
+    inherit musicRoot lidarr host ntfyUrl;
+  });
+in
+{
+  # Long-lived Music Assistant API token for the `brian` user. music/sync only
+  # requires an authenticated caller, not an admin one.
+  sops.secrets.ma_token = {};
+
+  systemd.tmpfiles.rules = [ "d ${stateDir} 0755 root root -" ];
+
+  # --------------------------------------------------------------- change watch
+  systemd.services.music-sync = {
+    description = "Refresh music libraries when the shared music tree changes";
+    after = [ "podman-lidarr.service" "network-online.target" "var-lib-media.mount" ];
+    wants = [ "network-online.target" ];
+    unitConfig.OnFailure = "music-sync-notify-failure.service";
+    serviceConfig = {
+      Type = "oneshot";
+      # Well above the measured 1.3s cold walk, but low enough that a hung NFS
+      # mount fails the run instead of pinning the timer forever.
+      TimeoutStartSec = "5m";
+      ExecStart = lib.concatStringsSep " " [
+        "${pkgs.python3}/bin/python3" "${./music-sync.py}" "${syncSpec}"
+      ];
+    };
+  };
+
+  systemd.timers.music-sync = {
+    description = "Poll the music tree for changes";
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnBootSec = "3m";
+      OnUnitInactiveSec = "2m";
+      AccuracySec = "15s";
+    };
+  };
+
+  # ---------------------------------------------------------------- daily audit
+  systemd.services.music-library-audit = {
+    description = "Repair Lidarr artist folders and report unimported music";
+    after = [ "podman-lidarr.service" "network-online.target" "var-lib-media.mount" ];
+    wants = [ "network-online.target" ];
+    unitConfig.OnFailure = "music-sync-notify-failure.service";
+    serviceConfig = {
+      Type = "oneshot";
+      TimeoutStartSec = "15m";
+      ExecStart = lib.concatStringsSep " " [
+        "${pkgs.python3}/bin/python3" "${./music-library-audit.py}" "${auditSpec}"
+      ];
+    };
+  };
+
+  systemd.timers.music-library-audit = {
+    description = "Daily Lidarr music library audit";
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnCalendar = "09:30";
+      RandomizedDelaySec = "20m";
+      Persistent = true;
+    };
+  };
+
+  systemd.services.music-sync-notify-failure = {
+    description = "Notify ntfy of a failed music library sync";
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = "${pkgs.curl}/bin/curl -s "
+        + "--connect-timeout 5 --max-time 30 --retry 3 --retry-delay 10 --retry-all-errors "
+        + "-H 'Title: Music library sync FAILED' "
+        + "-H 'Priority: 3' "
+        + "-H 'Tags: musical_note' "
+        + "-d '${host} music library sync failed — check journalctl -u music-sync -u music-library-audit' "
+        + ntfyUrl;
+    };
+  };
+}

--- a/modules/music-sync.py
+++ b/modules/music-sync.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Trigger targeted library rescans when the music tree changes.
+
+Every filesystem watcher on /var/lib/media/music is inert: the share is NFS from
+erebor and the writers are elsewhere (an arr container on pirateship, or a CD rip
+copied straight onto the NAS), so inotify never delivers events. Lidarr's
+RootFolderWatchingService, Navidrome's scanner watcher and Music Assistant all
+end up relying on their own schedules -- 1 day, 1 hour and 12 hours respectively.
+
+This replaces that with change detection cheap enough to run every two minutes:
+stat the directories (not the files) and compare mtimes. Any file added, removed
+or renamed bumps its parent directory's mtime, so ~278 stats cover a 2000-track
+library in well under a second.
+
+Nothing is scanned while the library is idle. When something does change, only
+the artists that actually changed are refreshed.
+"""
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+SPEC = sys.argv[1]
+
+with open(SPEC) as fh:
+    spec = json.load(fh)
+
+ROOT = spec["musicRoot"]
+STATE = spec["statePath"]
+notes = []
+
+
+def http(url, method="GET", headers=None, data=None, timeout=30):
+    req = urllib.request.Request(url, method=method, data=data, headers=headers or {})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        raw = r.read()
+    return json.loads(raw) if raw and raw[:1] in b"[{" else raw
+
+
+def fingerprint():
+    """Map every directory under ROOT to its mtime.
+
+    Directories only. A track file's own mtime is irrelevant -- what matters is
+    whether the set of files changed, and that always shows up as a bump on the
+    containing directory. Tag edits in place are the one thing this misses; those
+    come from Lidarr, which rescans the artist itself as part of the edit.
+    """
+    out = {}
+    stack = [ROOT]
+    while stack:
+        d = stack.pop()
+        try:
+            st = os.stat(d)
+            entries = list(os.scandir(d))
+        except (FileNotFoundError, NotADirectoryError, PermissionError):
+            # Raced with a write, or vanished mid-walk. Skipping it means this
+            # pass records a different fingerprint than the next one will, which
+            # just defers the trigger by one tick -- exactly what we want while
+            # the tree is still moving.
+            continue
+        out[os.path.relpath(d, ROOT)] = st.st_mtime_ns
+        for e in entries:
+            try:
+                if e.is_dir(follow_symlinks=False):
+                    stack.append(e.path)
+            except OSError:
+                continue
+    return out
+
+
+def load_state():
+    try:
+        with open(STATE) as fh:
+            s = json.load(fh)
+        return s.get("pending") or {}, s.get("synced") or {}
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}, {}
+
+
+def save_state(pending, synced):
+    tmp = STATE + ".tmp"
+    with open(tmp, "w") as fh:
+        json.dump({"pending": pending, "synced": synced}, fh)
+    os.replace(tmp, STATE)
+
+
+# ------------------------------------------------------------------ detection
+cur = fingerprint()
+if not cur:
+    sys.exit("music root %r is empty or unreadable -- refusing to act on it" % ROOT)
+
+pending, synced = load_state()
+
+if not pending and not synced:
+    # First run. Adopt the current tree as the baseline instead of treating all
+    # 99 artists as changed; anything added before this point is picked up by
+    # music-library-audit and Lidarr's own daily rescan.
+    save_state(cur, cur)
+    print("baseline recorded (%d dirs)" % len(cur))
+    sys.exit(0)
+
+if cur != pending:
+    # Something is moving. Wait for it to settle rather than scanning a
+    # half-copied album -- this debounce is the reason the timer is short.
+    save_state(cur, synced)
+    print("change detected, waiting for the tree to settle")
+    sys.exit(0)
+
+if cur == synced:
+    print("no change")
+    sys.exit(0)
+
+# Stable for a full interval and different from what we last synced.
+changed_top = set()
+for path in set(cur) | set(synced):
+    if cur.get(path) == synced.get(path):
+        continue
+    top = path.split(os.sep, 1)[0]
+    if top != ".":
+        changed_top.add(top)
+
+print("settled; changed top-level dirs: %s" % (sorted(changed_top) or "(root only)"))
+
+
+# --------------------------------------------------------------------- lidarr
+def sync_lidarr(cfg):
+    with open(cfg["configPath"]) as fh:
+        key = re.search(r"<ApiKey>([^<]+)</ApiKey>", fh.read()).group(1)
+    base = "http://127.0.0.1:%d/api/v1" % cfg["port"]
+    hdr = {"X-Api-Key": key, "Content-Type": "application/json"}
+
+    artists = http(base + "/artist", headers=hdr)
+    # Lidarr sees the share at a different prefix: the container bind-mounts
+    # /var/lib/media at /media, so its artist paths read /media/music/<Artist>.
+    by_name = {}
+    for a in artists:
+        p = a["path"].rstrip("/")
+        if os.path.dirname(p) == cfg["lidarrRoot"]:
+            by_name[os.path.basename(p)] = a
+
+    hit, miss = [], []
+    for name in sorted(changed_top):
+        a = by_name.get(name)
+        if a is None:
+            miss.append(name)
+            continue
+        # RefreshArtist, not RescanArtist. RescanArtist only scans disk, and a
+        # freshly ripped album that Lidarr's DB has no release for cannot be
+        # attached to anything -- the album entity comes from MusicBrainz on
+        # refresh. mediamanagement has rescanAfterRefresh=always, so a refresh
+        # rescans the disk too. This only fires for artists that changed.
+        http(base + "/command", "POST", hdr,
+             json.dumps({"name": "RefreshArtist", "artistId": a["id"]}).encode())
+        hit.append(a["artistName"])
+
+    if hit:
+        notes.append("lidarr  refreshed %d artist(s): %s" % (len(hit), ", ".join(hit)))
+    if miss:
+        # Not an error. Lidarr cannot adopt a folder on its own -- it has no way
+        # to guess the MusicBrainz artist -- so these need a Library Import.
+        # music-library-audit is what nags about them.
+        notes.append("lidarr  %d changed dir(s) belong to no artist: %s"
+                     % (len(miss), ", ".join(miss)))
+
+
+# ------------------------------------------------------------ music assistant
+# Navidrome is deliberately absent here. Its own quick scan is already an mtime
+# walk that finishes in under a second, so it just needed a shorter schedule
+# (see modules/navidrome.nix) rather than a push: 0.63.2 does not advertise the
+# apiKeyAuthentication OpenSubsonic extension, so triggering it over the API
+# would mean storing a user's password to save a couple of minutes.
+def sync_music_assistant(cfg):
+    with open(cfg["tokenFile"]) as fh:
+        token = fh.read().strip()
+    # providers is deliberately omitted so every provider syncs. The filesystem
+    # one is incremental (it compares a per-file mtime checksum) and the rest are
+    # builtin and finish in milliseconds.
+    http(cfg["url"] + "/api", "POST",
+         {"Authorization": "Bearer " + token, "Content-Type": "application/json"},
+         json.dumps({"command": "music/sync", "message_id": "music-sync", "args": {}}).encode())
+    notes.append("mass    triggered music/sync")
+
+
+failed = []
+for label, fn, cfg in (
+    ("lidarr", sync_lidarr, spec.get("lidarr")),
+    ("music-assistant", sync_music_assistant, spec.get("musicAssistant")),
+):
+    if not cfg:
+        continue
+    try:
+        fn(cfg)
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError, KeyError) as e:
+        failed.append("%s: %s" % (label, e))
+
+print("\n".join(notes) if notes else "nothing to do")
+
+if failed:
+    # Leave `synced` alone so the next tick retries. `pending` is already `cur`,
+    # so a retry fires immediately rather than waiting for another change.
+    save_state(cur, synced)
+    sys.exit("failed to notify: %s" % "; ".join(failed))
+
+save_state(cur, cur)

--- a/modules/navidrome.nix
+++ b/modules/navidrome.nix
@@ -22,11 +22,19 @@
       Address     = "0.0.0.0";
       Port        = 4533;
       LogLevel    = "info";
-      # The library is on the erebor NFS mount. Navidrome's filesystem watcher
-      # (inotify) only sees writes made locally on pirateship — albums added on
-      # the NAS directly never fire events. Re-enable periodic scanning (disabled
-      # by default in 0.62) so remote additions get picked up automatically.
-      "Scanner.Schedule" = "1h";
+      # The library is on the erebor NFS mount, so Navidrome's inotify watcher is
+      # inert — measured over 24h, scans only ever landed on the hour, even
+      # though Lidarr imported four times that day. Periodic scanning (disabled
+      # by default in 0.62) is the only thing that actually picks changes up.
+      #
+      # 5m, not 1h: a quick scan is itself just a directory-mtime walk and takes
+      # 0.4–2.3s (17.7s when it finds something), so this is close to free and
+      # keeps Navidrome roughly in step with modules/music-sync.nix, which drives
+      # Lidarr and Music Assistant on a 2-minute tick. Navidrome is deliberately
+      # not pushed to from there: 0.63.2 does not advertise the
+      # apiKeyAuthentication OpenSubsonic extension, so triggering startScan
+      # would mean keeping a user's password in sops to save ~3 minutes.
+      "Scanner.Schedule" = "5m";
     };
   };
 

--- a/secrets/pirateship.yaml
+++ b/secrets/pirateship.yaml
@@ -6,6 +6,7 @@ attic_push_token: ENC[AES256_GCM,data:X8oBfNLTYVbrc42rYNEUOElNhkOgLXeJac3Tc3HL/9
 recyclarr_sonarr_api_key: ENC[AES256_GCM,data:KW6/nJx2wBiys1CWcyEGR5MuUHaeexjnaJNg7Qkq5qw=,iv:oWxuIr/RuDf4bHSg9FKsctraQ9oB+dlTHWWi72UGbbM=,tag:nlHi4MVwC1E+7RnEMfmF2w==,type:str]
 recyclarr_radarr_api_key: ENC[AES256_GCM,data:yAHFCJvqEpazAI1N9Oxxr54VzavBPM49toxWPqXI7sQ=,iv:Ng5kY6PQGlegyb+2DwrRhZMGMVg6QN/6B958VrVic0I=,tag:2Ha5xaUhgvjzOgxHg6WORQ==,type:str]
 jellyfin_api_key: ENC[AES256_GCM,data:LUmuz0V+ZfH1fRuzWS2n9WsuXhbQ165j+lvFvJ0Ed8M=,iv:QXF89EVAp/GgRs1BUBOrR0/HQapOrfhW+FKN99EGEn4=,tag:I5YYW2mRmcIrlTiEDmg8Aw==,type:str]
+ma_token: ENC[AES256_GCM,data:2A8sOiDeB4iipEaQCu/8Ooun6Udq8sOAVDAkIzzEpPdvjg5TO5nN6LFIazI9oiyT8B2BYodkZ/hY7asskaR/I/Vvk0e7EAR2KAlihV8L1PL3DmOU5+kPLR3WL27UPueSmC3Kt1s5uUO073ocQK06C/LBZqKi/voGBtwKXAQ5xhPKLzCqIqAX89PkbSLb8ExDUOzNMK71GsZEykXgHeEbfxQzzQDprRVr9e02IjbaLI5rb15UedoqKLBlSFo9mkKiL8zPBwX8K1ZGUXUfZWB42IO8cNBR+71VBw+PgA2S/ms0jC0gQChZKf1zEVh2zjJxBhD2pfCx62GD1NSjqIHTqf1W+kHbRc0vBlG2QcqErFOk0NaX0n9KDFWphb/MOPcqsvvW0GdD+hxwfk8wIcjqh9mMoObmraaRPK58U94Y1OKu1QCjgjT/YJIudmNiayLIbTN8GoSFm/DjDDuAxAEOYY9XqoiA6SiJDesrnwbsxqDso1c=,iv:hcTTrHQmxtcqtZMa8Kz2nD313qAMqZ8La7wiAHYJvfk=,tag:nh0dM+j36WJCBf+u9NnzQw==,type:str]
 sops:
     age:
         - enc: |
@@ -26,7 +27,7 @@ sops:
             cAHpgf2kYBKeeExqLXrjXUNaC6pLw0fWsadg5zeWh5bMi/1il5/feg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1tl6nxc9gl080x7vxy8l9mc5eps0sp33rwdlylt2uvhkuy6l6hvsqmcx0av
-    lastmodified: "2026-08-01T01:07:36Z"
-    mac: ENC[AES256_GCM,data:F9Ah6YYLSPLSGg5xymHRk0Quwym999vJROa6LpoJhPsONQWAljMUdlDr3t/SK/Zxg592qCvQrxahQru8wYyj0W+M1tFYCqp/ALLfr1LyW5sktvLbWgS+tmFwgAh61+E1xVcdQ2s8naffr08cjdYSIGitP0PL7S4j/oYpOXbuPX4=,iv:9jPz0i/3OD58AOoqhmxhK63EDiDWUD3RuqY5xte/+yM=,tag:8C3+h/xJqmXCEU45/DM0eA==,type:str]
+    lastmodified: "2026-08-01T02:26:35Z"
+    mac: ENC[AES256_GCM,data:PhXyDD2fXA0qbMpR6QRoz/KLf8v3r9ItMlJSN2sE2NQiMziq7NEAym4Isg5p6O/PhbFLHcBtKTWl5IifSKla52ch9fio6rNECwYOQtipFv37njAjU2X7kiZ9il7vSQPsAw0G1GVq4GeNaO+xpcwLemKBBJKDhB5WFQabV/yBLZ8=,iv:SwGKBf5Bw6Gc0fdJTD9EXXqw2WOG4Zt30gJwuINWpio=,tag:NY23GCAfxq3jCsn1LA+71Q==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3

--- a/secrets/rivendell.yaml
+++ b/secrets/rivendell.yaml
@@ -5,10 +5,10 @@ restic_r2_env: ENC[AES256_GCM,data:izh+EytFeWgEsjXVBPHeChCaG0vZbb7sK6jbBYTU/nFwZ
 caddy_cloudflare_env: ENC[AES256_GCM,data:WFPTC7qC7TbwqZ0TyL6/JlyH82hWX9P9FbDSItcQreyR3Jhwv/2rH8ENVITNzmU/2UGXlgeYhi7RmImgFQg=,iv:7JvkA6H4L5KyrTKTzfbdEzz9rDOkfZwos75LalYHfrI=,tag:8FBQ4g9K5eShfwxe+VSlPw==,type:str]
 attic_push_token: ENC[AES256_GCM,data:lfhbyi/gnjMrzTQopPSC8Y1zTRZGwBz4ZxV94wIPFUYTYefnhTU2CMOdP8YGPqM4zcGO2mxE1sRaQGPtqHgKBFLcv88yc59o0QLgjPVwp8823ysfgF1RUzbh+DnURuNQ/Ly7U3QB6qvEtb8vMA1fDBsFzwUHF075GLp8FNc/Dlsxivcehd0NMA/w7b4P7kp7ohl4nDvZ+53oBTGbpL4u1Ihldztf7US3mOcHKEKhZw73oUFwWSie68rAu7KxO9KAhsG7WLY0DaZFepxAHZRTBvno87Ugn5TMgbvdDq32lUge9YRPL9rG/dsQmgnNESAEAESqAByq3J7/0vOHncA5rjMt7SjAAx3FWM3mxXJ3hUzWmXRXwCFvS41RRbnWQYMA6a2OjgwJD2KSioAJBlikkp/ZcqIJ9nybRPjQMeAqHl60UC+mToejf5MIcHSHhuiJF/CT+vz2MvxYzoXqr29kfZLjtYvdPuq/2krw00tPEvzaD2F+5z7NbyG9UEKCrRgcMyoZ1lMnzKk61PjsFGkjiTTG4zP2cmZxKtrYWdCBkH6iYnaUkd7j35GAm9ZkusmBQdkZX68jr6PkRagIwK6KZvUU6COZv7wdo3Q1TzdgMH8X1uR06A7gU8y8E0qFjtiHFzSruHyiPZL2ocoqPrjrQ12ISNfmfYn9jVn0o3XjT7mQbUqi9f/HXwbK46aictKU5hvS8P6EAFT8OQCqoyD6G1hanGcTPOePbA+UuGPVYf+w8s83+yl2hwTPy3UdjbP4/+wWZAUkcWqUN6KOuII0JjfUzKsr6VHGpBdobUIE9rpVNdi478Pdlk7UfFdY60bdtGLk2ZYFHkzBsnzok0wRRhc4Y+EB4HhgJBRHY7AUEGYtJs+EWiywYwHsmaf8sf3xnG/BlelsMlBEd16niMOR6YsaCQ8DLUn8VNSkVvomgrVol9SqvCgpOlslQ4R7NF6Ae1lavzOttNcymdQPR56ioV0lCRovCqUNDkjYomheV95u/pmFScjqPNNP8XspBDPPSRNQsMGFq+zZwQWlwX2HhuIl4HtMpsWAduQ6SIwMdm+yuchVPjblmsfsOraJ7gF9pHgP00hUmoniRqcDH+EfPd93yZxmnvhSTrll8UTeBXgp+Qwe+RNX5LmQOlGqjQ5i95bTpo3D5CKcQ+nstFb9swXz7IQ=,iv:LOhtfI/BQ6B6wYQSCy3JuF4DHZRbjMjOr37lbtJaH5Q=,tag:9gzrmhJy23Wu5ic/bxgYqw==,type:str]
 github_runner_token: ENC[AES256_GCM,data:JeBjDV7j5BVh2HHz4AOf//nx5i/aIoQlEtpIPvFBdgeM80F908S0SdcAahpxNhYT3J2Z8BtlTyLUKrvXcciZJ754keNObAGkPH9YRFA2ZqeA86bYzbP0y7XRlnEY,iv:zFqKUPp2+Haw7lzfgmRajbpzQ2CEA4waicw8y6J5FK0=,tag:ZeejdpCjIiO7jbDH4v+FQg==,type:str]
+ma_token: ENC[AES256_GCM,data:hr9DOmVnqVWQvc+tE0NuiHya0Du20yiBtNVbwmqBNI1xCv2IZN7YryUHiidqOz/ycRpl/AbCpSYbBw57EK6fUYqGbq8+ilJtOcyujJJqdAkmwMDsprkr1yciiVIgQ0BgEUqXlnUpPb+a83VmQJHC3MP40HQBVHvBIG/2qMSawDAqHdkF+kCamVj+5ivRVSfLRY0Ru8pUfVD2if0mjJ1mvdB7zyWQfSSuyMMhhWI6SnH3LEa+8zBEGMqemgOXcGhKKT1zUUMCridWtAZgF6gBPUAH1mkd5yx6SIsd3KinZZhRrICyPCP/pcUJ1vK4Ib1B+73jPYVXj9VhZTvHbXgQRUy1jPbBBRBahzDfAV3wey/1mB3jWtjunfc0RTGla2U/pjfwp34hmQtkJRKmEZX8E9Pa5ob8rHUW2LQCv4hbljuUtZfLNjR/E9iu47kpMw+WGCrQdQgzNXwH09/v5cW2VTV0naDJi7XOHNycWq4xdAuGvtM=,iv:MfvYF24FkLbiV8wonly5o1B2YbmX6H0rHEHo4WwjWyM=,tag:0enVjgZbN8Tqid7tf7RqMg==,type:str]
 sops:
     age:
-        - recipient: age1v6fjpzeu847h3qj7wnxwhdvyjsl42hj2uams8r5p9tjj246v9a3q6va7s7
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFRjE0VjVYcFVRU1NKSlc2
             cXVOdWxaVHBYdklMYTc1SHZqeWJkTzJSTm1VClEwbTJzdEZzVHpFZ0Z6bFhMODZB
@@ -16,8 +16,8 @@ sops:
             d050SHlaR2l6aHRmOGJiZjRPdnorRmMKqyEge+wEeUmipDg94vqqWpSgruWouEPJ
             KQI15u1CybDDuX/u3Pr8gFKr1Ko0Oc2j0WO7qHfOqNdc+xzvsikTHQ==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1tl6nxc9gl080x7vxy8l9mc5eps0sp33rwdlylt2uvhkuy6l6hvsqmcx0av
-          enc: |
+          recipient: age1v6fjpzeu847h3qj7wnxwhdvyjsl42hj2uams8r5p9tjj246v9a3q6va7s7
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlRmQwamJESkd5Um9xemZu
             QUN2V0t4TUVFQWhzVW95SXo2d0NnU2hyeVVJCnE3elZtT2hHNDhJNFpPSUMzamxw
@@ -25,7 +25,8 @@ sops:
             bTRCbmNrR2R6Z2IybVpZOHFwQnRkekUKv6jp3EYcM20BTlbmt2zDvW0b0V518JNI
             O4b7wA5rzSphF3OmcZGLNjn2Bkcj8Z7ewuVuDlu/Iw7k+PwptcjNCw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-26T17:19:53Z"
-    mac: ENC[AES256_GCM,data:mAwcprs2nOq1gX7I/UXBGKctw2fSTDwM5QcSvYCHww0SICJYXRRLMZCK8hsFIYtAXjZ2j/+oL0IWMMyaewKcENirSUnxbn0xGUmTTxrWyeoLWZ0qgOF8mCvQc8O3MSyuxxA4JKEn5OEG50cBPQ0Ld5ImiZg3/3hrc/NlL5Ty27I=,iv:83brMVOyPDoUSX+E3pa7qEWoM4cwv/P+kb9UGIvBC6Y=,tag:VHhkSu0qejV3z5Acvx1hMg==,type:str]
+          recipient: age1tl6nxc9gl080x7vxy8l9mc5eps0sp33rwdlylt2uvhkuy6l6hvsqmcx0av
+    lastmodified: "2026-08-01T02:20:31Z"
+    mac: ENC[AES256_GCM,data:BYHHlC86os5vFb80s1+O04lvGDyz66DJBtJz72BbFanhRGpofIbst/HyR9Kt97LhXVVpMOmfclHnNOgkf2GOpz8YiLReswPfTmCo2XXbjZuc1bVVai+4KfzOJf/xpQ2rxTQPbH6+rDmUJZAjHkPTjZy5RdH1uCyAiWUQRrAUEVs=,iv:sbCFXntrMOozhRquemJjeK7nZehT8THPT4INodkgQoU=,tag:xeIGR3WXsOj0DxfQEOMBEg==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.12.2
+    version: 3.13.3

--- a/secrets/rivendell.yaml
+++ b/secrets/rivendell.yaml
@@ -5,7 +5,6 @@ restic_r2_env: ENC[AES256_GCM,data:izh+EytFeWgEsjXVBPHeChCaG0vZbb7sK6jbBYTU/nFwZ
 caddy_cloudflare_env: ENC[AES256_GCM,data:WFPTC7qC7TbwqZ0TyL6/JlyH82hWX9P9FbDSItcQreyR3Jhwv/2rH8ENVITNzmU/2UGXlgeYhi7RmImgFQg=,iv:7JvkA6H4L5KyrTKTzfbdEzz9rDOkfZwos75LalYHfrI=,tag:8FBQ4g9K5eShfwxe+VSlPw==,type:str]
 attic_push_token: ENC[AES256_GCM,data:lfhbyi/gnjMrzTQopPSC8Y1zTRZGwBz4ZxV94wIPFUYTYefnhTU2CMOdP8YGPqM4zcGO2mxE1sRaQGPtqHgKBFLcv88yc59o0QLgjPVwp8823ysfgF1RUzbh+DnURuNQ/Ly7U3QB6qvEtb8vMA1fDBsFzwUHF075GLp8FNc/Dlsxivcehd0NMA/w7b4P7kp7ohl4nDvZ+53oBTGbpL4u1Ihldztf7US3mOcHKEKhZw73oUFwWSie68rAu7KxO9KAhsG7WLY0DaZFepxAHZRTBvno87Ugn5TMgbvdDq32lUge9YRPL9rG/dsQmgnNESAEAESqAByq3J7/0vOHncA5rjMt7SjAAx3FWM3mxXJ3hUzWmXRXwCFvS41RRbnWQYMA6a2OjgwJD2KSioAJBlikkp/ZcqIJ9nybRPjQMeAqHl60UC+mToejf5MIcHSHhuiJF/CT+vz2MvxYzoXqr29kfZLjtYvdPuq/2krw00tPEvzaD2F+5z7NbyG9UEKCrRgcMyoZ1lMnzKk61PjsFGkjiTTG4zP2cmZxKtrYWdCBkH6iYnaUkd7j35GAm9ZkusmBQdkZX68jr6PkRagIwK6KZvUU6COZv7wdo3Q1TzdgMH8X1uR06A7gU8y8E0qFjtiHFzSruHyiPZL2ocoqPrjrQ12ISNfmfYn9jVn0o3XjT7mQbUqi9f/HXwbK46aictKU5hvS8P6EAFT8OQCqoyD6G1hanGcTPOePbA+UuGPVYf+w8s83+yl2hwTPy3UdjbP4/+wWZAUkcWqUN6KOuII0JjfUzKsr6VHGpBdobUIE9rpVNdi478Pdlk7UfFdY60bdtGLk2ZYFHkzBsnzok0wRRhc4Y+EB4HhgJBRHY7AUEGYtJs+EWiywYwHsmaf8sf3xnG/BlelsMlBEd16niMOR6YsaCQ8DLUn8VNSkVvomgrVol9SqvCgpOlslQ4R7NF6Ae1lavzOttNcymdQPR56ioV0lCRovCqUNDkjYomheV95u/pmFScjqPNNP8XspBDPPSRNQsMGFq+zZwQWlwX2HhuIl4HtMpsWAduQ6SIwMdm+yuchVPjblmsfsOraJ7gF9pHgP00hUmoniRqcDH+EfPd93yZxmnvhSTrll8UTeBXgp+Qwe+RNX5LmQOlGqjQ5i95bTpo3D5CKcQ+nstFb9swXz7IQ=,iv:LOhtfI/BQ6B6wYQSCy3JuF4DHZRbjMjOr37lbtJaH5Q=,tag:9gzrmhJy23Wu5ic/bxgYqw==,type:str]
 github_runner_token: ENC[AES256_GCM,data:JeBjDV7j5BVh2HHz4AOf//nx5i/aIoQlEtpIPvFBdgeM80F908S0SdcAahpxNhYT3J2Z8BtlTyLUKrvXcciZJ754keNObAGkPH9YRFA2ZqeA86bYzbP0y7XRlnEY,iv:zFqKUPp2+Haw7lzfgmRajbpzQ2CEA4waicw8y6J5FK0=,tag:ZeejdpCjIiO7jbDH4v+FQg==,type:str]
-ma_token: ENC[AES256_GCM,data:hr9DOmVnqVWQvc+tE0NuiHya0Du20yiBtNVbwmqBNI1xCv2IZN7YryUHiidqOz/ycRpl/AbCpSYbBw57EK6fUYqGbq8+ilJtOcyujJJqdAkmwMDsprkr1yciiVIgQ0BgEUqXlnUpPb+a83VmQJHC3MP40HQBVHvBIG/2qMSawDAqHdkF+kCamVj+5ivRVSfLRY0Ru8pUfVD2if0mjJ1mvdB7zyWQfSSuyMMhhWI6SnH3LEa+8zBEGMqemgOXcGhKKT1zUUMCridWtAZgF6gBPUAH1mkd5yx6SIsd3KinZZhRrICyPCP/pcUJ1vK4Ib1B+73jPYVXj9VhZTvHbXgQRUy1jPbBBRBahzDfAV3wey/1mB3jWtjunfc0RTGla2U/pjfwp34hmQtkJRKmEZX8E9Pa5ob8rHUW2LQCv4hbljuUtZfLNjR/E9iu47kpMw+WGCrQdQgzNXwH09/v5cW2VTV0naDJi7XOHNycWq4xdAuGvtM=,iv:MfvYF24FkLbiV8wonly5o1B2YbmX6H0rHEHo4WwjWyM=,tag:0enVjgZbN8Tqid7tf7RqMg==,type:str]
 sops:
     age:
         - enc: |
@@ -26,7 +25,7 @@ sops:
             O4b7wA5rzSphF3OmcZGLNjn2Bkcj8Z7ewuVuDlu/Iw7k+PwptcjNCw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1tl6nxc9gl080x7vxy8l9mc5eps0sp33rwdlylt2uvhkuy6l6hvsqmcx0av
-    lastmodified: "2026-08-01T02:20:31Z"
-    mac: ENC[AES256_GCM,data:BYHHlC86os5vFb80s1+O04lvGDyz66DJBtJz72BbFanhRGpofIbst/HyR9Kt97LhXVVpMOmfclHnNOgkf2GOpz8YiLReswPfTmCo2XXbjZuc1bVVai+4KfzOJf/xpQ2rxTQPbH6+rDmUJZAjHkPTjZy5RdH1uCyAiWUQRrAUEVs=,iv:sbCFXntrMOozhRquemJjeK7nZehT8THPT4INodkgQoU=,tag:xeIGR3WXsOj0DxfQEOMBEg==,type:str]
+    lastmodified: "2026-08-01T02:26:26Z"
+    mac: ENC[AES256_GCM,data:6fAfRUe9jm9CLkdR86xdKU2xccSjvrxFkI/F1fYfq0HHBR2QBmjGv0AStLRjGV1I9BtefD++IHNSfGYXEn96J+o5tfE/mPnd/dLQH82giVIXT/Xz33fWqZ5UHaMJCmY+jjjZBlENeA/RPEjlpL076J6561HYBLd+nmm5bbNi/ZI=,iv:VBJV7xHasVnyXUGvYtmWn9HlkPmbWhtm2u+gfJXVT1A=,tag:uu/kvLRD2MP+7W5IE0l/tw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3


### PR DESCRIPTION
Three services read `/var/lib/media/music` and **every filesystem watcher on it is
inert** — inotify does not deliver events for writes made by a different NFS
client, and the writers are always elsewhere. Third instance of the same root
cause as Jellyfin (#485) and Bazarr.

Each service had silently fallen back to its own schedule, and the real cadences
were worse than the configured ones looked:

| service | configured | **actually** |
|---|---|---|
| Navidrome | `Scanner.Schedule "1h"` | hourly; watcher never fired (24h of journal: scans only on the hour, despite 4 Lidarr imports that day) |
| Music Assistant | `provider_sync_interval_* 30` | **every 12 h** |
| Lidarr `RescanFolders` | daily | daily, ~6 min/run |

`provider_sync_interval_*` in MA's `settings.json` is **dead config** — nothing in
2.9.9 reads those keys. The real schedule is a hardcoded
`TaskSchedule.hourly(every=12)`. MA's floor is 1 h, so sub-hourly needs an
external push.

## Approach

`music-sync.timer` on the pirateship **host** polls the ~278 *directory* mtimes
every 2 min (measured 226–293 ms CPU idle). Directories only: any file
add/remove/rename bumps its parent's mtime, so this beats stat-ing 2000 files. A
change must persist a full interval before firing, so a half-copied album is
never scanned mid-write. First run adopts a baseline rather than refreshing all
100 artists.

`RefreshArtist`, not `RescanArtist` — a freshly ripped album has no MusicBrainz
album entity in Lidarr's DB, and only a refresh fetches one.

Runs on the host rather than as a Lidarr custom script deliberately: a script in
the container would need rivendell added to `FIREWALL_OUTBOUND_SUBNETS`, and
rivendell is a blocky DNS host. Nothing was added to that list.

Navidrome is not pushed to, just moved to `Scanner.Schedule = "5m"`: its quick
scan is itself an mtime walk (0.4–2.3 s), and 0.63.2 does not advertise the
`apiKeyAuthentication` OpenSubsonic extension, so a push would mean a user
password in sops to save ~3 min.

## Lidarr silently skipped 11 of 99 artists

`renameTracks` + `artistFolderFormat {Artist Name}` makes Lidarr derive a
canonical MusicBrainz folder that rarely matches a rip folder — artist `AC/DC`
pointed at `AC+DC` while the files were in `ACDC/`. Those artists keep working
(Library Import attached the files once) but every later scan skips them, so
newly ripped albums into that folder are invisible **forever**. This was the
reported "Lidarr doesn't pick up CD rips consistently".

The only trace is a *missing* log line: healthy artists log
`Scanning /media/music/X`; broken ones skip straight to `Completed scanning disk`
with `MetadataService|Artist folder does not exist`.

`music-library-audit.timer` (daily) repoints an artist when all its track files
sit under one folder (`moveFiles=false`, no data movement). It **never** guesses:
an artist with no folder and no track files gets only a same-name *suggestion* in
the ntfy message, since attaching the wrong folder is worse than leaving it
broken. Folders owned by no artist are reported as needing a manual Library
Import — Lidarr cannot adopt one itself.

Also adds the native `wiim` provider and documents that
`services.music-assistant.providers` **installs dependencies rather than enabling
providers** — nixpkgs patches out MA's pip path and replaces it with a hard
error, so a provider enabled in MA's own `settings.json` but missing here fails
to import on every startup.

## Verification

- **State machine**, 8 sequential runs: baseline → `no change` → debounce → fire
  (correct artist identified) → same on removal.
- **End-to-end**, confirmed from both services' own state at the same instant,
  not from the script's self-report: Lidarr logged
  `RefreshArtistService|Updating Info for Artist 'Nirvana'` →
  `DiskScanService|Completed scanning disk`, and all four MA filesystem sync
  tasks moved to `last_run=02:33:33.7 status=success`. The *scheduled* refresh 19
  min earlier had logged `Skipping refresh of Artist 'Nirvana'`.
- **Token auth proven with a negative test** (lesson from #486, where a passing
  arr `notification/test` proved nothing): correct token 200, wrong token 401,
  no token 401.
- **Idle**: three consecutive runs `no change`, 226–293 ms CPU, zero API calls.
- **Audit**: repointed 10/11 on first run, verified at the file level
  (`OutKast` → 39 files in `Outkast/`, `R.E.M.` → 11 in `REM/`). Only `Aven`
  remains unresolved, correctly — added but never downloaded.
- Neither unit is in `homelab.postUpgradeCheck.services`: that check asserts
  `is-active` == active, false for a timer-driven oneshot between runs. They use
  `OnFailure` → ntfy.

Both hosts deployed and confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)