### PR TITLE
fix(music): correct the NFS watcher claim, and backfill MA artist metadata

### DIFF
--- a/modules/ma-metadata-backfill.py
+++ b/modules/ma-metadata-backfill.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Refresh Music Assistant artists whose metadata is missing but already stamped.
+
+MA ships a daily "Scan missing artist metadata" task, and it cannot fix these.
+Its query is
+
+    (no images OR no description) AND last_refresh IS NULL
+
+so the moment an artist is refreshed once, it is excluded forever -- even if the
+refresh returned nothing and the artist still has no image and no biography.
+121 of 221 library artists were in exactly that state when this was written,
+stamped back in March and April, and the task completed in 2.9s finding zero
+work to do. (Compare the equivalent playlist task, which correctly uses
+`last_refresh < now - REFRESH_INTERVAL`. The artist query looks like an
+oversight.)
+
+Nothing else fills the gap on its own: MA fetches metadata lazily when you open
+an artist page, which is why the library looks half-populated -- whatever you
+have browsed to has data and the rest does not.
+
+`_update_artist_metadata` guards only on REFRESH_INTERVAL (90 days), so these
+artists are perfectly eligible; nobody ever asks. This asks, in bounded batches
+so the backlog drains over a few days rather than hammering MusicBrainz,
+TheAudioDB and fanart.tv in one burst. Once drained it is a no-op.
+"""
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+SPEC = sys.argv[1]
+
+with open(SPEC) as fh:
+    spec = json.load(fh)
+
+URL = spec["url"]
+LIMIT = spec["batchSize"]
+with open(spec["tokenFile"]) as fh:
+    TOKEN = fh.read().strip()
+HDR = {"Authorization": "Bearer " + TOKEN, "Content-Type": "application/json"}
+
+
+def cmd(command, args=None, timeout=120):
+    body = json.dumps({"command": command, "message_id": "backfill", "args": args or {}})
+    req = urllib.request.Request(URL + "/api", method="POST", data=body.encode(), headers=HDR)
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        raw = r.read()
+    return json.loads(raw) if raw else None
+
+
+def incomplete(item):
+    m = item.get("metadata") or {}
+    return not (m.get("images") or []) or m.get("description") is None
+
+
+artists = cmd("music/artists/library_items", {"limit": 5000})
+if isinstance(artists, dict):
+    artists = artists.get("items", artists.get("result", []))
+
+stuck = [a for a in artists if incomplete(a)]
+if not stuck:
+    print("up to date: %d artists, all have images and a description" % len(artists))
+    sys.exit(0)
+
+batch = stuck[:LIMIT]
+print("%d/%d artists missing metadata; refreshing %d this run"
+      % (len(stuck), len(artists), len(batch)))
+
+fixed = unchanged = failed = 0
+for a in batch:
+    name = a.get("name") or "?"
+    uri = a.get("uri") or "library://artist/%s" % a.get("item_id")
+    before = a.get("metadata") or {}
+    try:
+        res = cmd("metadata/update_metadata", {"item": uri})
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        print("  FAIL    %-34s %s" % (name[:34], e))
+        failed += 1
+        continue
+    after = (res or {}).get("metadata") or {}
+    gained_images = len(after.get("images") or []) - len(before.get("images") or [])
+    gained_desc = bool(after.get("description")) and not bool(before.get("description"))
+    if gained_images > 0 or gained_desc:
+        fixed += 1
+        print("  updated %-34s%s%s" % (
+            name[:34],
+            " +%d images" % gained_images if gained_images > 0 else "",
+            " +description" if gained_desc else ""))
+    else:
+        # Genuinely absent upstream (obscure or non-Latin-script artists are the
+        # usual case). Nothing to do about it; it will be retried next run, which
+        # is cheap because the providers answer from cache.
+        unchanged += 1
+    time.sleep(1)
+
+print("updated=%d no-data=%d failed=%d remaining=%d"
+      % (fixed, unchanged, failed, len(stuck) - len(batch)))
+
+# Deliberately exit 0 when providers simply had nothing: that is not a fault and
+# should not trip OnFailure. A transport failure is.
+if failed and not fixed:
+    sys.exit("every refresh in this batch failed to reach Music Assistant")

--- a/modules/music-sync.nix
+++ b/modules/music-sync.nix
@@ -1,24 +1,34 @@
 # modules/music-sync.nix — keep Lidarr, Navidrome and Music Assistant in step
 #
-# Four services read the same erebor NFS share at /var/lib/media/music, and every
-# filesystem watcher on it is inert. inotify does not deliver events for writes
-# made by a different NFS client, and the writers are always elsewhere: an arr
-# container on pirateship, or a CD rip copied straight onto the NAS. Same root
-# cause already documented for Jellyfin in modules/jellyfin-notify.nix and for
-# Bazarr's realtime monitor.
+# Four services read the same erebor NFS share at /var/lib/media/music. inotify
+# on an NFS mount is delivered for writes made through that mount by the SAME
+# host, and not for writes made by any other client. So the blind spots are:
 #
-# So each service fell back to its own schedule, and the real numbers were much
-# worse than the configured ones looked:
+#   same host   pirateship writes  -> Navidrome (pirateship) sees them. Its
+#                                     watcher works and always has.
+#   other host  pirateship writes  -> Jellyfin (orthanc) and Music Assistant
+#                                     (rivendell) never see them. Same cause as
+#                                     modules/jellyfin-notify.nix and Bazarr.
+#   no host     erebor SMB writes  -> nobody sees them. This is the manual
+#                                     CD-rip path, and it is the one that
+#                                     matters most here.
 #
-#   Navidrome         Scanner.Schedule "1h"        -- honoured; watcher never fired.
-#                     24h of journal showed scans only on the hour, despite Lidarr
-#                     importing at 09:11, 10:06, 10:44 and 13:40 that day.
+# Music Assistant additionally has no filesystem watcher at all, so it is
+# schedule-only regardless of where the write came from.
+#
+# The schedules those services fell back to were much worse than the configured
+# values suggested:
+#
 #   Music Assistant   provider_sync_interval_* 30  -- DEAD CONFIG. Nothing in 2.9.9
 #                     reads those keys; the real schedule is a hardcoded
 #                     TaskSchedule.hourly(every=12) in models/music_provider.py.
 #                     The library synced twice a day.
 #   Lidarr            RescanFolders daily          -- and ~6 min per run, since it
-#                     walks all 99 artist folders.
+#                     walks all 99 artist folders. Whether Lidarr's own
+#                     RootFolderWatchingService catches same-host writes is
+#                     untested; it is not relied on either way.
+#   Navidrome         Scanner.Schedule, now 5m     -- safety net for NAS-direct
+#                     writes only; its watcher covers the same-host case.
 #
 # music-sync.timer replaces that with detection cheap enough to run every two
 # minutes: stat the ~278 directories (0.09s warm, 1.28s cold) and compare mtimes.
@@ -80,6 +90,14 @@ let
   auditSpec = pkgs.writeText "music-library-audit.json" (builtins.toJSON {
     inherit musicRoot lidarr host ntfyUrl;
   });
+
+  metadataSpec = pkgs.writeText "ma-metadata-backfill.json" (builtins.toJSON {
+    url = "http://10.0.1.9:8095";
+    tokenFile = config.sops.secrets.ma_token.path;
+    # Small enough to be polite to MusicBrainz/TheAudioDB/fanart.tv, large
+    # enough that a ~120-artist backlog drains in a few days.
+    batchSize = 40;
+  });
 in
 {
   # Long-lived Music Assistant API token for the `brian` user. music/sync only
@@ -136,6 +154,34 @@ in
     timerConfig = {
       OnCalendar = "09:30";
       RandomizedDelaySec = "20m";
+      Persistent = true;
+    };
+  };
+
+  # ------------------------------------------------- MA artist metadata backfill
+  # Works around MA's own scan task, whose query excludes any artist that has a
+  # last_refresh stamp — so an artist refreshed once that came back empty is
+  # never retried. See ma-metadata-backfill.py.
+  systemd.services.ma-metadata-backfill = {
+    description = "Backfill missing Music Assistant artist metadata";
+    after = [ "network-online.target" ];
+    wants = [ "network-online.target" ];
+    unitConfig.OnFailure = "music-sync-notify-failure.service";
+    serviceConfig = {
+      Type = "oneshot";
+      TimeoutStartSec = "30m";
+      ExecStart = lib.concatStringsSep " " [
+        "${pkgs.python3}/bin/python3" "${./ma-metadata-backfill.py}" "${metadataSpec}"
+      ];
+    };
+  };
+
+  systemd.timers.ma-metadata-backfill = {
+    description = "Daily Music Assistant artist metadata backfill";
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnCalendar = "10:15";
+      RandomizedDelaySec = "30m";
       Persistent = true;
     };
   };

--- a/modules/navidrome.nix
+++ b/modules/navidrome.nix
@@ -22,18 +22,28 @@
       Address     = "0.0.0.0";
       Port        = 4533;
       LogLevel    = "info";
-      # The library is on the erebor NFS mount, so Navidrome's inotify watcher is
-      # inert — measured over 24h, scans only ever landed on the hour, even
-      # though Lidarr imported four times that day. Periodic scanning (disabled
-      # by default in 0.62) is the only thing that actually picks changes up.
+      # Navidrome's inotify watcher DOES work here, contrary to what an earlier
+      # version of this comment claimed: inotify is delivered for writes made
+      # through this mount by this host, and both Navidrome and the arr
+      # containers are on pirateship. The journal has ~92 "Watcher: Triggering
+      # scan for changed folders" events going back to March.
       #
-      # 5m, not 1h: a quick scan is itself just a directory-mtime walk and takes
-      # 0.4–2.3s (17.7s when it finds something), so this is close to free and
-      # keeps Navidrome roughly in step with modules/music-sync.nix, which drives
-      # Lidarr and Music Assistant on a 2-minute tick. Navidrome is deliberately
-      # not pushed to from there: 0.63.2 does not advertise the
-      # apiKeyAuthentication OpenSubsonic extension, so triggering startScan
-      # would mean keeping a user's password in sops to save ~3 minutes.
+      # (The earlier claim came from grepping the journal for "Starting scan",
+      # which only matches *scheduled* scans — watcher-driven scans log an
+      # entirely different string. Do not re-derive that conclusion from a
+      # "Starting scan" grep.)
+      #
+      # What the watcher genuinely cannot see is a write made on another NFS
+      # client — i.e. an album copied straight onto erebor over SMB, which is
+      # exactly the manual CD-rip path. Periodic scanning is the safety net for
+      # that case, not the primary mechanism.
+      #
+      # 5m rather than 1h because a quick scan is itself just a directory-mtime
+      # walk (0.4–2.3s, 17.7s when it finds something), so bounding the
+      # NAS-direct blind spot to five minutes is close to free. Navidrome is
+      # deliberately not pushed to from modules/music-sync.nix: 0.63.2 does not
+      # advertise the apiKeyAuthentication OpenSubsonic extension, so triggering
+      # startScan would mean keeping a user's password in sops.
       "Scanner.Schedule" = "5m";
     };
   };


### PR DESCRIPTION
Follow-up to #490. Two findings from digging into the remaining music questions.

## 1. Correction to #490

#490 claimed "every filesystem watcher on the share is inert" and that
Navidrome's watcher "never fired". **That is wrong.** inotify on NFS *is*
delivered for writes made through the mount by the same host, and Navidrome and
the arr containers are both on pirateship — the journal has ~92
`Watcher: Triggering scan for changed folders` events going back to March.

The bad conclusion came from grepping the journal for `Starting scan`, which only
matches *scheduled* scans; watcher-driven scans log a different string entirely.

The actual rule, now stated in both module comments:

| write origin | watcher host | sees it? |
|---|---|---|
| pirateship | pirateship (Navidrome) | **yes** |
| pirateship | orthanc (Jellyfin) / rivendell (MA) | no — different NFS client |
| erebor directly over SMB | anywhere | no — the manual CD-rip path |

**No design change follows.** MA has no watcher at all *and* sits on another
host; Lidarr's drifted-artist-path bug is untouched; and the NAS-direct rip path
— the case that prompted this work — is still blind everywhere. Navidrome's `5m`
schedule is a safety net for that case rather than the primary mechanism, which
is what the comment now says instead of overclaiming.

Also corrected: Navidrome's scanner runs as a subprocess, so a new PID per scan
in the journal is not the service restarting.

## 2. MA's metadata scan task cannot repair a stale artist

Its query is

```sql
(no images OR no description) AND last_refresh IS NULL
```

so an artist refreshed once that came back empty is excluded **forever** — its
`last_refresh` is set. **121 of 221 library artists were stuck like that**,
stamped in March and April. The task ran in 2.9s and found zero work.

The equivalent *playlist* task uses `last_refresh < now - REFRESH_INTERVAL`, so
the artist query looks like an oversight. `_update_artist_metadata` itself only
guards on `REFRESH_INTERVAL` (90 days), so these artists are eligible — nothing
ever asks.

This is why the library looked half-populated: MA fetches lazily when you open an
artist page, so browsed artists had data and the rest didn't.

`ma-metadata-backfill` asks, 40/day, and no-ops once drained.

### Verification

- Traced the root cause to the SQL in `_scan_missing_artist_metadata`, then
  confirmed against `library.db`: 221 artists, **0** never-refreshed, 47 without
  images, 120 without descriptions, and **0** matching MA's own query — which is
  exactly why its run was a no-op.
- Proved the mechanism on a batch of 5 before automating: 4 gained descriptions,
  1 gained an image, all confirmed persisted in `library.db` (120 → 116 missing).
  The one that gained nothing is a Japanese-titled artist absent upstream.
- Exits 0 when providers simply have no data — that is not a fault and must not
  trip `OnFailure`. Only a transport failure does.
- `nix flake check --no-build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)