### PR TITLE
fix(music): widen ma-metadata-backfill timeout to 60m

### DIFF
--- a/modules/music-sync.nix
+++ b/modules/music-sync.nix
@@ -169,7 +169,13 @@ in
     unitConfig.OnFailure = "music-sync-notify-failure.service";
     serviceConfig = {
       Type = "oneshot";
-      TimeoutStartSec = "30m";
+      # Measured at ~25s per artist -- the cost is MA querying MusicBrainz,
+      # TheAudioDB, fanart.tv and Wikipedia under their rate limits, not the
+      # script. A 40-artist batch is therefore ~17 min; 60m leaves room for a
+      # slow provider rather than killing a run mid-batch and firing OnFailure.
+      # Artists already done are committed as it goes, so a kill only costs the
+      # remainder of that batch.
+      TimeoutStartSec = "60m";
       ExecStart = lib.concatStringsSep " " [
         "${pkgs.python3}/bin/python3" "${./ma-metadata-backfill.py}" "${metadataSpec}"
       ];


### PR DESCRIPTION
Missed the merge window on #491.

Measured **~25s per artist** — the cost is Music Assistant querying MusicBrainz,
TheAudioDB, fanart.tv and Wikipedia under their rate limits, not the script. A
40-artist batch is therefore ~17 min, so the 30m that landed in #491 left only
1.8× headroom. A slow provider would kill the run mid-batch and fire a spurious
`OnFailure` alert.

Artists already processed are committed as it goes, so a kill only ever costs the
remainder of that batch — but a false alarm is still noise, and this is free
insurance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)