### PR TITLE
feat(rivendell): run Matter Server and OTBR as native NixOS services

### DIFF
--- a/hosts/rivendell.nix
+++ b/hosts/rivendell.nix
@@ -125,8 +125,20 @@
   # ---------------------------------------------------------------------------
   homelab.backup.paths = [
     "/var/lib/homeassistant/config"
-    "/var/lib/matter-server/data"
-    "/var/lib/otbr/data"
+
+    # Matter fabric. NOT /var/lib/matter-server — services.matter-server runs
+    # with DynamicUser=true, so systemd keeps the real state directory at
+    # /var/lib/private/matter-server and leaves a SYMLINK at the unprefixed
+    # path. restic archives a symlink as a symlink, so backing up the
+    # unprefixed path would silently capture a 30-byte link and none of the
+    # fabric — and the loss would only surface at restore time, when every
+    # Matter device would need re-commissioning.
+    "/var/lib/private/matter-server"
+
+    # Thread dataset. otbr-agent runs as root (no DynamicUser), so
+    # StateDirectory=thread is a real directory and needs no private/ prefix.
+    "/var/lib/thread"
+
     "/var/lib/caddy"
     "/var/lib/music-assistant"
   ];

--- a/modules/homeassistant.nix
+++ b/modules/homeassistant.nix
@@ -1,23 +1,28 @@
 # modules/homeassistant.nix — Home Assistant + Matter Server + OTBR
 #
-# Home Assistant: home automation platform (port 8123)
-# Matter Server: bridges Matter-protocol IoT devices into HA
-# OTBR (OpenThread Border Router): Thread border router via ZBT-2 USB dongle
+# Home Assistant: home automation platform (port 8123) — still a CONTAINER
+# Matter Server: bridges Matter-protocol IoT devices into HA — native
+# OTBR (OpenThread Border Router): Thread border router via ZBT-2 — native
 #
-# All containers use host networking — required for mDNS/Zeroconf
-# device discovery and Matter/Thread commissioning to work correctly.
-# With host networking, HA and Matter Server communicate via localhost
-# (Matter Server WebSocket on port 5580 is not exposed externally).
-# OTBR REST API on port 8086 is accessed by HA's Thread integration via localhost.
+# Migration status (staged deliberately; see Plan.md):
+#   Stage 1 (2026-08-01, this commit): matter-server + otbr -> native modules.
+#     Done first and alone so the Matter fabric and Thread dataset moves are
+#     verified while HA is still the known-good container talking to them over
+#     the same localhost ports (5580 / 8081). Neither port changes, so HA needs
+#     no reconfiguration.
+#   Stage 2 (pending): home-assistant container -> services.home-assistant.
+#     Gate is satisfied as of 2026-08-01 — nixpkgs-unstable carries 2026.7.4,
+#     exactly the version running here. Re-verify before starting: the gate is
+#     "nixpkgs >= running", and HA ships a new minor every month.
 #
-# --privileged is used for full hardware access: USB dongles (Zigbee,
-# Z-Wave, Thread/ZBT-2), Bluetooth (Matter commissioning), and multicast
-# networking. Any USB device plugged in will be accessible inside the
-# container automatically.
+# The HA container keeps host networking (mDNS/Zeroconf discovery) and
+# --privileged (USB dongles, Bluetooth for Matter commissioning, multicast).
+# HA reaches Matter Server on localhost:5580 and OTBR's REST API on
+# localhost:8081; both native services bind loopback, so nothing is exposed.
 #
 # ZBT-2 (Nabu Casa, 303a:831a) presents as /dev/ttyACM0 in Thread RCP mode.
 # If running Multi-PAN firmware (Zigbee + Thread concurrently), a cpcd
-# container would be required between the USB device and OTBR.
+# service would be required between the USB device and OTBR.
 
 { config, pkgs, lib, ... }:
 
@@ -40,77 +45,59 @@
       ];
     };
 
-    matter-server = {
-      image = "ghcr.io/home-assistant-libs/python-matter-server:stable@sha256:170aa093ce91c76cde4cc390918307590f0f5558fcec93f913af3cb019e6562a";
-      autoStart = true;
-      # --primary-interface eth0: bind mDNS/multicast to the Ethernet interface
-      # so Matter Server can discover WiFi devices on the local network.
-      # Without this it defaults to 'None' and mDNS discovery fails.
-      cmd = [ "--storage-path" "/data" "--primary-interface" "eth0" ];
-      volumes = [
-        "/var/lib/matter-server/data:/data"
-        # DBus access is required for Bluetooth (Matter commissioning).
-        "/run/dbus:/run/dbus:ro"
-      ];
-      extraOptions = [
-        "--network=host"
-        "--privileged"
-      ];
-    };
+  };
 
-    # OpenThread Border Router — Thread border router for HA's Thread integration.
-    # ZBT-2 USB dongle (/dev/ttyACM0) acts as the Thread radio (RCP mode).
-    # HA Thread integration URL: http://localhost:8081
-    #
-    # The REST API binds to 127.0.0.1:8081 by default in this image version.
-    # HA reaches it via localhost (both share host networking). No LAN exposure.
-    #
-    # NAT64/NAT44 disabled (NAT64=0, DOCKER=0):
-    #   The openthread/otbr image defaults NAT64=1 and DOCKER=1, which causes
-    #   the startup script to configure NAT via iptables-legacy. NixOS uses
-    #   nftables and does not load the ip_tables kernel modules, so iptables
-    #   fails with "Table does not exist" and the container exits.
-    #
-    #   For our use case — HA local control over Thread — NAT64 is not needed.
-    #   Thread devices communicate with HA directly over the mesh; they do not
-    #   need to reach IPv4 internet resources through the border router.
-    #
-    #   If internet-connected Thread devices are ever needed (e.g., devices that
-    #   phone home to IPv4 cloud services via the border router), re-enable NAT64
-    #   by removing the NAT64/DOCKER env vars and loading the required iptables
-    #   kernel modules in NixOS instead:
-    #
-    #     boot.kernelModules = [
-    #       "ip_tables" "iptable_filter" "iptable_nat" "iptable_mangle"
-    #       "ip6_tables" "ip6table_filter" "ip6table_nat"
-    #     ];
-    #
-    #   With those modules loaded, iptables-legacy inside the container can
-    #   coexist with the host's nftables firewall.
-    otbr = {
-      # Fully qualified (docker.io/) so podman does NOT treat this as an
-      # unqualified short name — that triggers a registry DNS lookup at container
-      # start which races blocky's restart during nixos-rebuild switch and fails
-      # activation (cost a rivendell rollback on 2026-06-24). See note below.
-      image = "docker.io/openthread/otbr:latest@sha256:0e679574c8a66ae3fc2d02ae345105958f2db23d866d3c20b391c7e08060631e";
-      autoStart = true;
-      cmd = [
-        "--radio-url" "spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=460800"
-        "--backbone-interface" "eth0"
-      ];
-      environment = {
-        NAT64 = "0";
-        DOCKER = "0";
-      };
-      volumes = [
-        "/var/lib/otbr/data:/var/lib/thread"
-      ];
-      extraOptions = [
-        "--network=host"
-        "--privileged"
-      ];
-    };
+  # ---------------------------------------------------------------------------
+  # Matter Server (native — migrated off the container 2026-08-01)
+  #
+  # --primary-interface eth0: binds mDNS/multicast to the Ethernet interface so
+  # Matter Server can discover WiFi devices. Without it the default is 'None'
+  # and mDNS discovery fails. extraArgs is an attrset run through
+  # lib.cli.toCommandLineGNU, so `primary-interface` becomes --primary-interface.
+  #
+  # The module runs the service with DynamicUser=true, which is why the fabric
+  # state ends up under /var/lib/private/matter-server (see the migration unit
+  # and the backup path note in hosts/rivendell.nix). It BindReadOnlyPaths
+  # /run/dbus, so Bluetooth commissioning still works without --privileged.
+  # ---------------------------------------------------------------------------
+  services.matter-server = {
+    enable = true;
+    port = 5580;
+    extraArgs.primary-interface = "eth0";
+  };
 
+  # ---------------------------------------------------------------------------
+  # OpenThread Border Router (native — migrated off the container 2026-08-01)
+  #
+  # ZBT-2 USB dongle (/dev/ttyACM0) is the Thread radio in RCP mode.
+  # HA's Thread integration reaches the REST API at http://localhost:8081,
+  # which is this module's default (rest.listenAddress 127.0.0.1, port 8081) —
+  # so the integration needs no reconfiguration.
+  #
+  # The NAT64=0 / DOCKER=0 workaround the container needed is GONE and must not
+  # be reintroduced. That existed because the openthread/otbr image shells out
+  # to iptables-legacy, which fails on NixOS ("Table does not exist") since the
+  # ip_tables kernel modules are never loaded. The native module instead runs
+  # otbr-firewall with config.networking.firewall.package — the host's own
+  # iptables — as ExecStartPre/ExecStopPost, so the rules land in the same
+  # backend the host firewall already uses. Verified on rivendell 2026-08-01:
+  # nftables.service inactive and `lsmod | grep -c ip_tables` = 0, i.e. the
+  # default iptables-nft backend, which is exactly what the module targets.
+  #
+  # The module also sets net.ipv{4,6}.conf.all.forwarding=1 and accept_ra=2 on
+  # each backbone interface. That is required for the Thread mesh to be routable
+  # and is deliberate.
+  # ---------------------------------------------------------------------------
+  services.openthread-border-router = {
+    enable = true;
+    backboneInterfaces = [ "eth0" ];
+    # Set the URL directly rather than radio.device + baudRate: the generated
+    # form is identical, and this keeps the string byte-for-byte what the
+    # container passed to --radio-url.
+    radio.url = "spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=460800";
+    # Defaults, restated because HA's Thread integration is pinned to them.
+    rest.listenAddress = "127.0.0.1";
+    rest.listenPort = 8081;
   };
 
   # Enable Bluetooth userspace daemon (bluetoothd) so HA and Matter Server
@@ -127,18 +114,122 @@
 
   systemd.tmpfiles.rules = [
     "d /var/lib/homeassistant/config 0755 root root -"
-    "d /var/lib/matter-server/data 0755 root root -"
-    "d /var/lib/otbr/data 0755 root root -"
   ];
 
-  # otbr's image is now fully qualified (docker.io/…, see above) so podman no
-  # longer does an unqualified short-name registry DNS lookup at container start —
-  # that lookup races blocky's restart during nixos-rebuild switch and fails
-  # activation. The `after = blocky.service` ordering is kept as belt-and-suspenders
-  # (blocky should be up before otbr regardless).
-  systemd.services.podman-otbr = {
-    after = [ "blocky.service" ];
+  # ---------------------------------------------------------------------------
+  # Container -> native state migrations (2026-08-01)
+  #
+  # These are one-shot and idempotent: each is a no-op once the old layout is
+  # gone, so they cost nothing on subsequent deploys and are safe to leave in
+  # place. Deleting them later is fine; they only matter for hosts still
+  # carrying the container-era directory layout.
+  #
+  # Getting these wrong is expensive in a way a rollback does NOT undo: losing
+  # the Matter fabric means re-commissioning every Matter device by hand, and
+  # losing the Thread dataset means re-forming the mesh. Both move data rather
+  # than copying, but only ever into an empty destination, and both bail out
+  # untouched if anything looks unexpected.
+  # ---------------------------------------------------------------------------
+
+  # Container: host /var/lib/matter-server/data -> container /data (--storage-path /data)
+  # Native:    storage-path is /var/lib/matter-server, and because the module
+  #            uses DynamicUser=true systemd places that at
+  #            /var/lib/private/matter-server behind a symlink.
+  #
+  # So the fabric files (chip_*.ini, chip.json, credentials/, <fabric-id>.json)
+  # must move up one level AND into /var/lib/private. We create that layout
+  # explicitly rather than relying on systemd to relocate a pre-existing real
+  # directory — systemd.exec(5) documents the symlink behaviour and the
+  # recursive chown of an existing StateDirectory, but not a migration of a real
+  # directory into /var/lib/private, so we do not depend on it. Ownership is
+  # left to systemd, which recursively chowns the StateDirectory to the dynamic
+  # UID on start.
+  systemd.services.matter-server-state-migration = {
+    description = "Move Matter fabric state from the container layout to the native one";
+    before = [ "matter-server.service" ];
+    requiredBy = [ "matter-server.service" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    script = ''
+      set -euo pipefail
+      old=/var/lib/matter-server
+      new=/var/lib/private/matter-server
+
+      # Already migrated: the path is the symlink systemd manages.
+      if [ -L "$old" ]; then exit 0; fi
+      # Nothing of the old shape to move.
+      if [ ! -d "$old/data" ]; then exit 0; fi
+
+      if [ -e "$new" ] && [ -n "$(ls -A "$new" 2>/dev/null)" ]; then
+        echo "refusing to migrate: $new already exists and is non-empty" >&2
+        exit 1
+      fi
+
+      mkdir -p /var/lib/private
+      chmod 0700 /var/lib/private
+      mkdir -p "$new"
+      # dotglob so nothing hidden is left behind; the fabric json is not hidden
+      # today but credentials/ has held dotfiles in past versions.
+      shopt -s dotglob nullglob
+      mv "$old"/data/* "$new"/
+      shopt -u dotglob nullglob
+      rmdir "$old/data"
+      # Remove the now-empty real directory so systemd can put its symlink here.
+      rmdir "$old"
+      echo "migrated Matter fabric state to $new"
+    '';
   };
 
-  homelab.postUpgradeCheck.services = [ "podman-homeassistant" "podman-matter-server" ];
+  # Container: host /var/lib/otbr/data -> container /var/lib/thread
+  # Native:    StateDirectory=thread -> /var/lib/thread (otbr-agent runs as root,
+  #            no DynamicUser, so this is a real directory, not a symlink).
+  #
+  # Holds the Thread network dataset, named for the radio's extended address
+  # (e.g. 0_d878f0fffe9ae872.data). Losing it drops the formed network.
+  systemd.services.otbr-state-migration = {
+    description = "Move Thread dataset from the container layout to the native one";
+    before = [ "otbr-agent.service" ];
+    requiredBy = [ "otbr-agent.service" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    script = ''
+      set -euo pipefail
+      old=/var/lib/otbr/data
+      new=/var/lib/thread
+
+      if [ ! -d "$old" ]; then exit 0; fi
+      shopt -s dotglob nullglob
+      files=("$old"/*)
+      if [ ''${#files[@]} -eq 0 ]; then rmdir "$old" 2>/dev/null || true; exit 0; fi
+
+      if [ -d "$new" ] && [ -n "$(ls -A "$new" 2>/dev/null)" ]; then
+        echo "refusing to migrate: $new already exists and is non-empty" >&2
+        exit 1
+      fi
+
+      mkdir -p "$new"
+      chmod 0700 "$new"
+      mv "''${files[@]}" "$new"/
+      shopt -u dotglob nullglob
+      rmdir "$old"
+      rmdir /var/lib/otbr 2>/dev/null || true
+      echo "migrated Thread dataset to $new"
+    '';
+  };
+
+  # The old podman-otbr `after = blocky.service` ordering is gone with the
+  # container. It existed because an unqualified image name made podman do a
+  # registry DNS lookup at container start, which raced blocky's restart during
+  # nixos-rebuild switch and failed activation (cost a rivendell rollback on
+  # 2026-06-24). otbr-agent pulls nothing at start, so the race cannot recur.
+
+  homelab.postUpgradeCheck.services = [
+    "podman-homeassistant"
+    "matter-server"
+    "otbr-agent"
+  ];
 }

--- a/renovate.json
+++ b/renovate.json
@@ -41,6 +41,11 @@
       "matchDepNames": ["docker.io/postgres"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "description": "Freeze the Home Assistant image while the native migration is staged. services.home-assistant can only take over when nixpkgs >= the running version; both are 2026.7.4 as of 2026-08-01, and letting the container roll forward to 2026.8.x would reopen that gate for another month. RE-ENABLE once modules/homeassistant.nix no longer declares this container.",
+      "matchDepNames": ["ghcr.io/home-assistant/home-assistant"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Stage 1 of taking rivendell container-free. matter-server and otbr move to
services.matter-server and services.openthread-border-router; the Home
Assistant container is deliberately left alone for a separate change, so
the fabric and dataset moves get verified while HA is still the known-good
container talking to both over unchanged localhost ports (5580 / 8081).

The NAT64=0 / DOCKER=0 workaround is gone and must not come back. It only
existed because the openthread/otbr image shells out to iptables-legacy,
which fails on NixOS since the ip_tables modules are never loaded. The
native module runs otbr-firewall with config.networking.firewall.package —
the host's own iptables — so the rules land in the backend the host firewall
already uses. Verified on rivendell: nftables.service inactive and
`lsmod | grep -c ip_tables` = 0, i.e. the iptables-nft default the module
targets. Generated otbr-agent ExecStart matches the container's arguments
byte-for-byte, including the radio URL.

State migrations ride along as idempotent oneshots ordered before each
service, because the container and native layouts differ:
  /var/lib/matter-server/data -> /var/lib/private/matter-server
  /var/lib/otbr/data          -> /var/lib/thread
matter-server's module uses DynamicUser=true, so systemd keeps its state
under /var/lib/private behind a symlink. Both units refuse to run if the
destination is already non-empty rather than merging into it. Losing either
payload is not rollback-recoverable: it means re-commissioning every Matter
device and re-forming the Thread mesh.

For the same reason homelab.backup.paths now names
/var/lib/private/matter-server, not /var/lib/matter-server — restic archives
a symlink as a symlink, so the old path would have backed up a link and none
of the fabric, and that only surfaces at restore time.

Also freezes the HA image in Renovate. services.home-assistant can only take
over when nixpkgs >= the running version; both are 2026.7.4 today, and
letting the container roll to 2026.8.x reopens that gate for another month.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
