### PR TITLE
fix(rivendell): pin matter-server vendorid to the fabric's own 0xFFF1

### DIFF
--- a/modules/homeassistant.nix
+++ b/modules/homeassistant.nix
@@ -63,7 +63,31 @@
   services.matter-server = {
     enable = true;
     port = 5580;
-    extraArgs.primary-interface = "eth0";
+    extraArgs = {
+      primary-interface = "eth0";
+
+      # MUST stay 65521 (0xFFF1). Do not "fix" this to Home Assistant's real
+      # vendor ID (4939) — that is what the nixpkgs module hardcodes, and it is
+      # wrong for THIS installation.
+      #
+      # The container never passed --vendorid, so the fabric was created with
+      # python-matter-server's default of 0xFFF1, and that is what is recorded
+      # on disk: chip.json caList = [{fabricId: 1, vendorId: 65521}].
+      #
+      # matter_server/server/stack.py reuses a stored FabricAdmin only when BOTH
+      # vendorId and fabricId match, and otherwise calls NewFabricAdmin() —
+      # which raises "Provided fabricId of 1 collides with an existing
+      # FabricAdmin instance!" because it collides on fabricId alone. With the
+      # module's 4939 the service crashed on startup with exactly that, then
+      # segfaulted on the way out (observed on the first native deploy,
+      # 2026-08-01).
+      #
+      # Changing this value orphans the existing fabric and requires
+      # re-commissioning every Matter device, so it is pinned to what the fabric
+      # on disk actually says. extraArgs is merged after the module's defaults
+      # (`{ ... } // cfg.extraArgs`), which is what makes the override possible.
+      vendorid = 65521;
+    };
   };
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
The native matter-server failed to start on the first deploy:

  ValueError: Provided fabricId of 1 collides with an existing
  FabricAdmin instance!

followed by a segfault on the way out. The nixpkgs module hardcodes
vendorid=4939 (Home Assistant's real vendor ID), but this installation's
fabric was created by the container, which never passed --vendorid and so
got python-matter-server's 0xFFF1 default. chip.json records it plainly:
caList = [{fabricId: 1, vendorId: 65521}].

matter_server/server/stack.py reuses a stored FabricAdmin only when BOTH
vendorId and fabricId match; otherwise it calls NewFabricAdmin(), which
collides on fabricId alone. So 4939 could never match the stored admin and
could never create a new one either.

Pinning vendorid to what the fabric on disk actually says is what keeps the
existing devices commissioned — changing it orphans the fabric and means
re-pairing every Matter device by hand.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
