### PR TITLE
docs: record arr-stack container decision and Piped playback diagnosis

### DIFF
--- a/modules/arr-stack.nix
+++ b/modules/arr-stack.nix
@@ -2,6 +2,53 @@
 #
 # All arr containers share gluetun's network namespace. If the VPN
 # drops, all containers lose connectivity — this is the kill switch.
+#
+# -----------------------------------------------------------------------------
+# Why this is still containers (reviewed 2026-08-01)
+#
+# DECISION: stay on gluetun + containers. This is a deliberate exception to the
+# "prefer declarative services" principle in CLAUDE.md, not an oversight, and it
+# stands until the declarative path works with no extra hassle. Re-read this
+# before anyone "fixes" it.
+#
+# What CHANGED — nixpkgs has caught up on the easy half. Every app in this
+# stack now has a native module with real declarative config:
+#   services.qbittorrent  — full deep-INI `serverConfig`. This alone would
+#     retire most of the preStart dance below: the PBKDF2 password hash,
+#     WebUI\LocalHostAuth, and the WebUI\BanList clearing all become plain Nix.
+#     Only Session\Interface genuinely needs runtime resolution, since it is
+#     tun0's address and changes per restart.
+#   services.sabnzbd      — `settings` covers the whole ini INCLUDING `servers`,
+#     with `secretFiles` for the Usenet password so it can finally come from
+#     sops. This retires the "SAB's ini is imperative" constraint and makes the
+#     open direct_unpack question a one-line change.
+#   services.{radarr,sonarr,prowlarr,lidarr} — `settings` plus
+#     `environmentFiles` taking ARR__SECTION__KEY=... for API keys.
+#
+# What did NOT change — the blocker was never the apps, it is the kill switch.
+# There is no native equivalent of gluetun's netns. The candidate is the
+# VPN-Confinement flake (Maroka-chan/VPN-Confinement), which does the netns and
+# DNS-leak part properly: it sets NetworkNamespacePath on each unit and blocks
+# /run/nscd and /run/resolvconf.
+#
+# The cost that makes it "extra hassle": VPN-Confinement has NO ProtonVPN
+# NAT-PMP port forwarding. gluetun's port-forward negotiation and its ~60s
+# renewal loop would have to be reimplemented here as a bespoke service —
+# libnatpmp is in nixpkgs, so it is possible, but it means owning the fiddliest
+# and most breakage-prone part of this stack by hand, and qbittorrent-port-sync
+# would have to be rebuilt on top of it. That is a real regression in
+# reliability traded for a principle, on the one service where a silent failure
+# means seeding stops and the VPN may not be protecting anything.
+#
+# Do not migrate this piecemeal. Plan.md Phase 3 moves the whole stack to
+# orthanc; the container->native change and the host move should happen in ONE
+# migration, not two, because each one separately re-tests the same qBittorrent
+# and gluetun behaviour that is expensive to verify.
+#
+# Revisit when EITHER: VPN-Confinement (or a successor) grows NAT-PMP port
+# forwarding, OR gluetun gains a supported way to hand its forwarded port to a
+# host-side service so the netns can hold only the torrent client.
+# -----------------------------------------------------------------------------
 
 { config, pkgs, lib, ... }:
 

--- a/modules/piped.nix
+++ b/modules/piped.nix
@@ -1,5 +1,42 @@
 # modules/piped.nix — Piped: privacy-respecting YouTube frontend
 #
+# -----------------------------------------------------------------------------
+# STATUS 2026-08-01: PLAYBACK IS BROKEN. Diagnosed, not yet fixed.
+#
+# The symptom reported as "the feed seems broken" is not the feed. Measured on
+# orthanc:
+#   - The feed pipeline is HEALTHY. 49 channels, 49 rows in `pubsub`, videos
+#     landing through today. The recurring "PubSub: queue size - 0 channels"
+#     log line means the queue is momentarily empty, NOT that nothing is
+#     subscribed — it is a red herring.
+#   - PLAYBACK is dead. /streams/<id> returns videoStreams=1, audioStreams=0,
+#     hls=false, dash=false on every video sampled; one returned outright
+#     "Could not get any stream". Piped needs separate adaptive audio, so zero
+#     audio streams means nothing can play. This is the standard signature of
+#     YouTube's PoToken/SABR enforcement defeating NewPipeExtractor.
+#
+# Why this will not fix itself: the running backend image was built
+# 2026-03-26, and TeamPiped/Piped-Backend's last commit upstream is 2026-05-29
+# with nothing addressing extraction. Renovate is digest-pinned to :latest and
+# has nothing newer to pull. The project is effectively dormant against a
+# problem that requires active maintenance.
+#
+# Path forward is a DECISION, not a patch — do not just bump the image:
+#   a) Replace with Invidious. nixpkgs has services.invidious (fully native,
+#      which also kills the piped-postgres container below), and iv-org is
+#      actively maintained — commits through 2026-08-01 including a
+#      "Hotfix - Fix YouTube change" on 2026-07-23. Invidious fights the same
+#      YouTube battle but is actually still fighting it.
+#   b) Retire the self-hosted YouTube frontend entirely.
+#   c) Stay on Piped and accept it as a subscription-feed reader whose links
+#      open elsewhere, since the feed half genuinely still works.
+#
+# NOTE the postgres 16-alpine container below is a principle violation on its
+# own (a database with a first-class NixOS module). Option (a) removes it for
+# free and retires the pinned-major upgrade task; do not migrate it separately
+# before this decision is made.
+# -----------------------------------------------------------------------------
+#
 # Four containers: postgres (DB), backend (API), frontend (nginx UI), proxy.
 # Video streams are served in redirect mode — the browser fetches video directly
 # from YouTube's CDN rather than proxying through the local instance. This avoids


### PR DESCRIPTION
arr-stack: nixpkgs has caught up on the apps — services.qbittorrent now has
a deep-INI serverConfig, services.sabnzbd covers the whole ini including
`servers` plus secretFiles for sops, and the four servarr modules take
settings + environmentFiles. None of that is the blocker. The blocker is
still the kill switch: VPN-Confinement does the netns properly but has no
ProtonVPN NAT-PMP port forwarding, so adopting it means reimplementing
gluetun's port-forward negotiation and renewal loop by hand. Staying on
containers is recorded as a deliberate exception to the declarative
principle, with the specific conditions that would reopen it.

piped: the reported "broken feed" is not the feed. The feed pipeline is
healthy (49 channels, 49 pubsub rows, videos landing today) and the
"PubSub: queue size - 0 channels" line is a red herring. Playback is what
is dead — /streams/<id> returns audioStreams=0 on every video sampled, the
signature of YouTube PoToken/SABR defeating NewPipeExtractor. Upstream is
dormant (last Piped-Backend commit 2026-05-29, running image built
2026-03-26), so a digest bump cannot fix it. Written up as a decision
between Invidious (actively maintained, native nixpkgs module, also removes
the piped-postgres container) and retiring the frontend.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
