### PR TITLE
fix(grafana): recreate datasource on uid change; fix deploy failure masking

### DIFF
--- a/modules/grafana.nix
+++ b/modules/grafana.nix
@@ -238,13 +238,35 @@ in
 
     provision = {
       enable = true;
-      datasources.settings.datasources = [{
-        name      = "Prometheus";
-        type      = "prometheus";
-        uid       = promDatasourceUid;
-        url       = "http://127.0.0.1:9090";
-        isDefault = true;
-      }];
+      # Grafana CANNOT change the uid of an existing datasource in place. Its
+      # provisioning update path looks the datasource up by uid, so introducing
+      # `uid` on a datasource that Grafana already created with a generated one
+      # fails with:
+      #
+      #   Failed to provision data sources: "Datasource provisioning error:
+      #   data source not found"
+      #
+      # and that failure is fatal — the provisioning module fails to start and
+      # takes the whole process with it. Observed on mirkwood 2026-08-01: 248
+      # restarts in a crash loop, never binding 3001, while systemd cheerfully
+      # reported "active (running)" for the few hundred ms each attempt lasted.
+      #
+      # deleteDatasources runs before datasources are written, so the old
+      # generated-uid record is removed and recreated with ours. It is keyed on
+      # name and is idempotent: after the first run there is nothing to delete.
+      # Safe because this datasource is fully declared here — nothing is lost by
+      # recreating it.
+      datasources.settings = {
+        deleteDatasources = [{ name = "Prometheus"; orgId = 1; }];
+        datasources = [{
+          name      = "Prometheus";
+          type      = "prometheus";
+          uid       = promDatasourceUid;
+          url       = "http://127.0.0.1:9090";
+          isDefault = true;
+          orgId     = 1;
+        }];
+      };
 
       # Dashboards are provisioned from the repo. Until 2026-08-01 only
       # datasources were provisioned and the single dashboard ("Blocky", uid

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -54,9 +54,24 @@ case "${1:-all}" in
     run_deploy pirateship &
     pid_p=$!
 
+    # Capture each rc into a variable BEFORE testing anything. The previous form
+    #     wait "$pid_p" || { [[ $status -eq 0 ]] && status=$?; }
+    # read $? *after* running [[ ]], so it captured the exit status of the test
+    # (0) rather than of wait. A pirateship-only failure therefore set status=0
+    # and the script exited success with a host left un-deployed — exactly what
+    # happened on 2026-08-01, where deploy-rs reported
+    # "Failed to build profile system on node pirateship: Copy exited with
+    # status 1" and the overall run still returned 0.
     status=0
-    wait "$pid_r" || status=$?
-    wait "$pid_p" || { [[ $status -eq 0 ]] && status=$?; }
+    rc_r=0; rc_p=0
+    wait "$pid_r" || rc_r=$?
+    wait "$pid_p" || rc_p=$?
+    [[ $rc_r -ne 0 ]] && status=$rc_r
+    [[ $status -eq 0 && $rc_p -ne 0 ]] && status=$rc_p
+
+    [[ $rc_r -ne 0 ]] && echo "deploy: rivendell FAILED (rc=$rc_r)" >&2
+    [[ $rc_p -ne 0 ]] && echo "deploy: pirateship FAILED (rc=$rc_p)" >&2
+
     exit $status
     ;;
   *)


### PR DESCRIPTION
Two bugs from #509, both of which reported success while being broken.

1. Grafana crash loop. #509 pinned the Prometheus datasource uid to
   `homelab-prometheus` so the checked-in dashboard JSON had something stable
   to reference. But Grafana cannot change the uid of an existing datasource in
   place — its provisioning update path looks the record up BY uid, so adding
   `uid` to a datasource Grafana had already created with a generated one fails:

     Failed to provision data sources: "Datasource provisioning error:
     data source not found"

   That failure is fatal: the provisioning module fails to start and takes the
   process down. mirkwood logged 248 restarts and never bound port 3001, while
   `systemctl is-active grafana` returned "active" throughout — each attempt
   lived a few hundred milliseconds, so unit state looked healthy the entire
   time. Caught only by curl returning http=000.

   deleteDatasources runs before datasources are written, so the old record is
   removed and recreated with the pinned uid. Idempotent — after the first run
   there is nothing to delete — and safe because the datasource is fully
   declared in Nix.

2. scripts/deploy masked a failed host. The parallel branch had:

     wait "$pid_p" || { [[ $status -eq 0 ]] && status=$?; }

   which reads $? AFTER running [[ ]], capturing the test's exit status (0)
   rather than wait's. A pirateship-only failure therefore set status=0 and the
   whole run exited success. That is precisely what happened on 2026-08-01:
   deploy-rs reported "Failed to build profile system on node pirateship: Copy
   exited with status 1", the script returned 0, and pirateship sat on a
   generation from 20260729 with none of the new exporters. Now each rc is
   captured before any test, and a failed host is named on stderr.

   The underlying copy failure was transient — pirateship deployed cleanly on
   retry — which is exactly why the masking mattered: nothing surfaced it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
