### PR TITLE
fix(observability): point Alertmanager at /hook, not /alert

### DIFF
--- a/modules/grafana.nix
+++ b/modules/grafana.nix
@@ -302,7 +302,15 @@ in
         };
         receivers = [{
           name = "ntfy";
-          webhook_configs = [{ url = "http://127.0.0.1:8000/alert"; }];
+          # Path MUST be /hook. alertmanager-ntfy serves the webhook there and
+          # 404s everything else (verified by probing /, /webhook, /alerts,
+          # /api/v1/alerts — all 404). Alertmanager does NOT retry a 404 into
+          # anything visible: the alert simply never arrives, while Prometheus
+          # shows it firing and Alertmanager shows it active, so both ends look
+          # healthy. Found on 2026-08-01 only by firing a synthetic alert and
+          # reading alertmanager-ntfy's own log, which showed
+          # `{"status": 404, "path": "/alert"}`.
+          webhook_configs = [{ url = "http://127.0.0.1:8000/hook"; }];
         }];
       };
     };


### PR DESCRIPTION
The webhook receiver was posting to /alert, which alertmanager-ntfy 404s.
Probing confirmed /hook is the only path it serves; /, /webhook, /alerts and
/api/v1/alerts all 404.

This failed in the worst possible way: Prometheus showed the alert firing,
Alertmanager showed it active, alertmanager-ntfy was running and healthy, and
no notification was ever delivered. Nothing in either component surfaced the
problem — the only evidence was alertmanager-ntfy's own request log:

  {"status": 404, "method": "POST", "path": "/alert", ...}

Found by firing a synthetic alert through the Alertmanager v2 API rather than
assuming the wiring was right, which is the only reason the alerting stack
added in #509 is not silently dead.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
