### PR TITLE
feat(invidious): native Invidious + companion as a Piped replacement trial

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -215,6 +215,7 @@
           ./modules/jellyfin.nix
           ./modules/attic.nix
           ./modules/piped.nix
+          ./modules/invidious.nix
           ./hosts/orthanc.nix
         ];
         specialArgs = { inherit inputs r2AccountId brianSshKey; };

--- a/modules/caddy.nix
+++ b/modules/caddy.nix
@@ -83,6 +83,17 @@ in
         }
         ${tlsConfig}
       '';
+      # Invidious — trial replacement for Piped, running alongside it.
+      # flush_interval -1 for the same reason as piped-proxy above: video is
+      # streamed through this vhost (invidious proxies its companion rather than
+      # exposing it), and Caddy's default response buffering makes Firefox's MSE
+      # time out before playback starts.
+      "invidious.theshire.io".extraConfig        = ''
+        reverse_proxy orthanc.home.theshire.io:3000 {
+          flush_interval -1
+        }
+        ${tlsConfig}
+      '';
 
       # pirateship backends
       "stream.theshire.io".extraConfig           = proxy "pirateship.home.theshire.io:4533";

--- a/modules/invidious.nix
+++ b/modules/invidious.nix
@@ -1,0 +1,248 @@
+# modules/invidious.nix — Invidious: privacy-respecting YouTube frontend
+#
+# -----------------------------------------------------------------------------
+# STATUS 2026-08-01: TRIAL, running SIDE BY SIDE with Piped.
+#
+# modules/piped.nix documents why Piped's playback is dead (YouTube PoToken/SABR
+# defeating a dormant NewPipeExtractor). This module is the candidate
+# replacement. Piped is deliberately left running and untouched — different
+# ports, different vhost, different database — so the two can be compared on the
+# same subscriptions before anything is removed. Retire Piped ONLY after
+# playback here has been verified over several days; see the exit criteria at
+# the bottom of this comment.
+#
+# -----------------------------------------------------------------------------
+# CORRECTION TO THE EARLIER ASSESSMENT: this is NOT a fully-native replacement.
+#
+# The "replace 4 containers with a native service" framing in the piped.nix note
+# was wrong on the one point that decides the whole thing. Invidious ALSO cannot
+# play video on its own any more. Since 2025 it delegates all stream retrieval
+# to `invidious-companion`, a separate Deno service that mints the po_token /
+# visitor_data pair YouTube now demands. Without it Invidious loads, searches,
+# and shows subscriptions — and every video fails. nixpkgs' own module test
+# asserts exactly this log line:
+#
+#   nixos/tests/invidious.nix:145
+#     "WARNING: Invidious companion is required to view and playback videos"
+#
+# And invidious-companion is NOT PACKAGED IN NIXPKGS (checked 2026-08-01: no
+# package under pkgs/by-name, no option in services.invidious; the only hit in
+# the entire tree is the assertion above). So it runs as a container here, and
+# that is unavoidable short of packaging a Deno app ourselves.
+#
+# `services.invidious.sig-helper` is NOT the answer either — it is the previous
+# generation of this mechanism, superseded upstream by companion, and nixpkgs
+# carries it at 0-unstable-2025-07-23. Do not enable it expecting playback.
+#
+# What this migration actually buys, then, is 4 containers → 1, with the
+# database and the application itself becoming native NixOS services. The
+# postgres 16-alpine container that piped.nix flags as a principle violation
+# goes away with Piped. That is a genuine improvement, just a smaller one than
+# advertised — and the real reason to switch is maintenance, not purity:
+#
+#   piped-backend image built  2026-03-26, last upstream commit 2026-05-29
+#   invidious-companion image built 2026-08-01  ← today
+#
+# The container is the piece doing the actual fighting with YouTube, and it is
+# the piece that is actively maintained.
+# -----------------------------------------------------------------------------
+#
+# Port layout (all on orthanc):
+#   3000 — invidious (native; 0.0.0.0 so Caddy on rivendell can reach it)
+#   8282 — invidious-companion (container; 127.0.0.1 ONLY — see below)
+#   postgres via local unix socket, peer auth, never exposed
+#
+# Caddy vhost on rivendell (see modules/caddy.nix):
+#   invidious.theshire.io → orthanc:3000
+#
+# Companion is bound to loopback and has NO `public_url` set, so Invidious
+# proxies every companion request itself and the browser only ever talks to the
+# one vhost. This is upstream's "simple setup". The alternative — exposing
+# companion directly on its own hostname so video bytes skip a hop — is a second
+# vhost and a second firewall hole for a latency win we have no evidence we
+# need. Revisit only if playback is measurably slow.
+#
+# Unlike Piped, NO Cloudflare Tunnel is required: Invidious polls YouTube for
+# subscription updates rather than receiving PubSubHubbub callbacks, so nothing
+# inbound from the public internet is needed. Leave the existing piped-api
+# tunnel in hosts/orthanc.nix alone until Piped is actually retired.
+#
+# Required sops secret (secrets/orthanc.yaml):
+#   invidious_companion_key — 16 chars EXACTLY (upstream rejects any other
+#                             length). Generate with `pwgen -s 16 1`.
+#
+# EXIT CRITERIA before retiring Piped (modules/piped.nix + its 4 containers,
+# the piped-api Cloudflare tunnel, and the docker.io/postgres pin in
+# renovate.json):
+#   1. Video playback works in the browser, on more than one video, on the
+#      device(s) actually used.
+#   2. Subscriptions imported and the feed populating.
+#   3. Still working ~a week later — companion's po_token can go stale, and the
+#      known upstream failure mode is "worked for weeks, then every video
+#      broke". A single good day proves nothing.
+#
+# Measured on first deploy 2026-08-01: 9 of 10 sampled videos returned 4 audio
+# + 18-22 video adaptive formats, and a real 256KiB `ftypdash` fragment was
+# pulled from googlevideo at 1.4MB/s. Compare Piped on the same day:
+# audioStreams=0 on every video sampled.
+#
+# The one failure is an upstream Invidious bug, NOT a playback/token problem:
+# jNQXAC9IVRw ("Me at the zoo", 2005) throws
+#   Exception: Expected Hash for #[]?(key : String), not String
+# in the Crystal metadata parser and returns HTTP 200 with an EMPTY BODY — note
+# the 200, so it does not look like a failure to anything checking status codes.
+# It is specific to that video's ancient metadata shape and is then cached
+# (1226ms first, ~780µs after). Not a blocker; worth re-checking after a version
+# bump.
+#
+# If promoting this past the trial, still to do: Homepage tile, a Gatus monitor,
+# and a decision on backing up the new native PostgreSQL (subscriptions live
+# there — a restic snapshot of a live data dir is not crash-consistent, so it
+# probably wants a pg_dump pre-hook rather than a raw path in
+# homelab.backup.paths).
+
+{ config, pkgs, lib, ... }:
+
+let
+  companionPort = 8282;
+in
+
+{
+  # ---------------------------------------------------------------------------
+  # Invidious (native) + PostgreSQL (native)
+  # ---------------------------------------------------------------------------
+
+  services.invidious = {
+    enable = true;
+    port = 3000;
+
+    # Caddy lives on rivendell, not here, so this cannot bind loopback the way
+    # a single-host setup would. The firewall rule below is what limits access.
+    address = "0.0.0.0";
+
+    domain = "invidious.theshire.io";
+
+    # nginx.enable stays FALSE — that option would pull in a whole nginx +
+    # ACME stack on orthanc to duplicate what Caddy already does on rivendell.
+    # It is also what would normally set https_only/external_port for us, hence
+    # setting them by hand below.
+    nginx.enable = false;
+
+    # createLocally provisions services.postgresql with a matching user and
+    # database and connects over the local unix socket with peer auth — no
+    # password anywhere. Note the module asserts db.user == db.dbname for this
+    # to work; both default to "invidious" on stateVersion >= 24.05.
+    database.createLocally = true;
+
+    settings = {
+      # MANDATORY behind a reverse proxy per upstream's config.example.yml —
+      # this is the port Invidious believes it is reachable on and uses to build
+      # absolute URLs. Wrong value here means subscription/redirect links point
+      # at :3000 and break from outside.
+      external_port = 443;
+      https_only = true;
+
+      # The companion handoff. private_url is Invidious → companion, in-host.
+      # No public_url on purpose — see the header comment.
+      invidious_companion = [
+        { private_url = "http://127.0.0.1:${toString companionPort}/companion"; }
+      ];
+
+      # Single-user instance. Registration is left ENABLED for now because an
+      # account is what holds subscriptions, and one has to be created before it
+      # can be locked down. Flip to false once the account exists.
+      registration_enabled = true;
+      login_enabled = true;
+
+      # Nothing here is public, so don't spend cycles building a "popular" page
+      # or publishing instance statistics to the public instance list.
+      popular_enabled = false;
+      statistics_enabled = false;
+
+      # With popular_enabled = false the stock default_home ("Popular") lands on
+      # a dead page — upstream's config.example.yml says that setting "has no
+      # effect when 'popular_enabled' is set to false", and `/` does in fact
+      # 302 straight to /feed/popular. Point it at the feed this instance
+      # actually exists to serve and drop Popular from the nav.
+      #
+      # Expect `/` to KEEP redirecting to /feed/popular when logged out — that
+      # is not this setting failing. src/invidious/routes/misc.cr:14-19 handles
+      # default_home == "Subscriptions" by checking for a user first and
+      # falling back to /feed/popular when there isn't one. Verified logged-out
+      # with curl; it only takes effect once signed in.
+      default_user_preferences = {
+        default_home = "Subscriptions";
+        feed_menu = [ "Subscriptions" "Trending" "Playlists" ];
+      };
+    };
+
+    # The 16-char companion key, rendered by sops and handed over as a systemd
+    # credential (see below). extraSettingsFile is merged into the config by the
+    # module with jq, so this file MUST be valid JSON — not YAML, and not a bare
+    # key. The same constraint applies to hmacKeyFile, which is why that one is
+    # left null and auto-generated into /var/lib/invidious/hmac_key instead.
+    extraSettingsFile = "/run/credentials/invidious.service/companion.json";
+  };
+
+  # LoadCredential rather than a group-readable secret: the upstream unit runs
+  # with DynamicUser=true AND PrivateUsers=true, and under PrivateUsers a
+  # supplementary group from the host does not map into the service's user
+  # namespace — the file would read as nogroup and access would fail. systemd
+  # reads credentials as root before any sandboxing and re-exposes them owned by
+  # the service's own uid, which sidesteps the whole problem.
+  systemd.services.invidious.serviceConfig.LoadCredential =
+    [ "companion.json:${config.sops.templates."invidious-companion.json".path}" ];
+
+  # One secret, two consumers, two formats. Templating from a single
+  # sops.placeholder is what keeps them from drifting — if these two ever
+  # disagree, Invidious and companion silently fail to authenticate to each
+  # other and every video breaks.
+  sops.secrets.invidious_companion_key = { };
+
+  sops.templates."invidious-companion.json".content = builtins.toJSON {
+    invidious_companion_key = config.sops.placeholder.invidious_companion_key;
+  };
+
+  # Consumed by podman as root, so default 0400 root:root is correct here.
+  sops.templates."invidious-companion.env".content =
+    "SERVER_SECRET_KEY=${config.sops.placeholder.invidious_companion_key}";
+
+  # ---------------------------------------------------------------------------
+  # invidious-companion (container — see header for why this cannot be native)
+  # ---------------------------------------------------------------------------
+
+  virtualisation.oci-containers.containers.invidious-companion = {
+    image = "quay.io/invidious/invidious-companion:latest@sha256:d7fd997abf03e4d01af05144f2896f3fe56747225df78d41c0431299b52ae191";
+    autoStart = true;
+
+    # Loopback-only. Invidious proxies for it; nothing external should reach it.
+    ports = [ "127.0.0.1:${toString companionPort}:${toString companionPort}" ];
+
+    environmentFiles = [ config.sops.templates."invidious-companion.env".path ];
+
+    # youtubei.js caches the player + the minted po_token here. Persisting it
+    # across restarts avoids re-solving YouTube's challenge on every boot.
+    volumes = [ "/var/lib/invidious-companion/cache:/var/tmp/youtubei.js:rw" ];
+
+    # Upstream's recommended hardening, verbatim from the production compose.
+    extraOptions = [
+      "--cap-drop=ALL"
+      "--security-opt=no-new-privileges"
+      "--read-only"
+    ];
+  };
+
+  systemd.tmpfiles.rules = [
+    "d /var/lib/invidious-companion       0755 root root -"
+    "d /var/lib/invidious-companion/cache 0777 root root -"
+  ];
+
+  # Only Invidious is reachable off-host, and only so Caddy can proxy it.
+  networking.firewall.allowedTCPPorts = [ 3000 ];
+
+  # NB for whoever reads `systemctl status invidious` and panics: the upstream
+  # module sets RuntimeMaxSec=1h with a randomized 5min offset, so this service
+  # is SUPPOSED to restart roughly hourly. Upstream requires it. A rising
+  # restart count is normal here and is not a crash loop.
+  homelab.postUpgradeCheck.services = [ "invidious" "podman-invidious-companion" ];
+}

--- a/secrets/orthanc.yaml
+++ b/secrets/orthanc.yaml
@@ -5,10 +5,10 @@ attic_env: ENC[AES256_GCM,data:nHUyRr5UhMmeH8QV2R9Y1Mx+alfTiU/mKdPO5oEr7bV8SlLLL
 minecraft_env: ENC[AES256_GCM,data:RYPlw1y+Y6yeQkBVnjCzb0grFmo0utbgeCKh2u9F3Xi0nTcA3f8WtoEmga14HJo+MnHBJH9a5csTUi8WLAXflnUUKNCjVRQa,iv:69pi0E9Joi28jmLjiE2WJjsH+8ojHsVGQgxUK1WaOGk=,tag:mEP5X/4jdGEZVIWZmuNaSw==,type:str]
 cloudflared_piped_credentials: ENC[AES256_GCM,data:Hgv5hnrJL0f75RY0+Oce8GZGw2ZpnHk0OCXs2M0QsK863rTnCTsqL4h8BNN2krB8jdRpmb2kX4HT/0G0Rp5QilN4l2X7+tniBFoskx1xlIE21a2pvJckYz4HzAZSpswNObuWF4OMVjDT4hOTP8qWHxS0gS7r7edQX7fImR+x2XNZWLBLvdgOMDlU3DA9x5LfeUJffSUANTojNVCWCe2DdATJwiGSR/zfdsI3PF3CBw==,iv:1+BaShWNt5bg6QOnTg52wdlMYwWcR57cS7eN5UQ+nsk=,tag:sW3rL3/OFw4AutsywmiMlw==,type:str]
 github_runner_token: ENC[AES256_GCM,data:1B4ztM03C7eC/RW3faAEIKir9/BIxGwwaeLDOWoEVZyVUmp2+gDcIL+6AFJSKORQfNJSa/8pXnqc7QnhBQoz6f55jzTIdjiFrEATBr3Vin7JCwBGPP7Wzx4HNzBc,iv:APCjAEFkpmUwsPr0jCkAeara+GPVT/5/hNJhmzW3Z10=,tag:mEozXaz/4cdWxJPALKgwbA==,type:str]
+invidious_companion_key: ENC[AES256_GCM,data:8lxxY+KrmUBLHAS89Jty7A==,iv:sZnzCjDM5QZG3eXkmHh5JYDtzIlVasQmSZ2DbGA9f+0=,tag:1dUAxFnpvAVLriejjWQcjQ==,type:str]
 sops:
     age:
-        - recipient: age170fgg0z30vu0as5q08eawyy0n30k6lnswq7ufe9zutfzwftxfs5s0dsvvu
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1OFZ4YUVpdm5EU0dKa1Bo
             ZDZBWG5CM202dTBMbFlLaUpyVWFnbEUvRUFvCmtLTWtWZTI4UUpBWWdxVjlqUyts
@@ -16,8 +16,8 @@ sops:
             NHJ4QXUxaUZxMWNiakpNdFVxaFZQUFkKMUxzeSwqgUVjXydBZL3bQmK/N4HCjR45
             OyDTs9yfiIAKh1FwRPYI//rFtXd9/rMwVcAvUVN5GCBpMlIzuFshvw==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1tl6nxc9gl080x7vxy8l9mc5eps0sp33rwdlylt2uvhkuy6l6hvsqmcx0av
-          enc: |
+          recipient: age170fgg0z30vu0as5q08eawyy0n30k6lnswq7ufe9zutfzwftxfs5s0dsvvu
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNZUEzaXBQNlpLQnhvdUdH
             NHJ2aURqekpKNEdscGgwQ1ZEY2JmZnZZR1JNCm5qVG1nMExKTm96R056a2UwOElp
@@ -25,7 +25,8 @@ sops:
             dk9wT1pjMTJWSVRBK1JkelM0WDg1c2sK71GhFpOyAuz85wHCnhhchJETOyF8iymq
             YdRyPP0UOLr1+PIw7o0ZLbBgbzvmUEcc1CIKkhJT8TwwoFNpdXvoCQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-26T16:52:48Z"
-    mac: ENC[AES256_GCM,data:QUDkE3OGq2jdX7hwugyH0cmU9lYzchRzDOwLyFP4rgHo6JfWIJg+j5RdDXmEBVvvsvvXvaLWCBbM9GsGULU0cDfoG79MGgavVBP3CcBZsyx4wZ1fAR3t8xtosOzg5v8yZvkLI6JsC8iVgRY6B8KBICTUIH322MJjkxkDvsjC5/E=,iv:aOYhQzP1/gja5Y/0tU7VD7UdSVt36qz9tfYxr6kGHkE=,tag:WbdBumK5yXf9EHA9rBMBtQ==,type:str]
+          recipient: age1tl6nxc9gl080x7vxy8l9mc5eps0sp33rwdlylt2uvhkuy6l6hvsqmcx0av
+    lastmodified: "2026-08-01T17:51:18Z"
+    mac: ENC[AES256_GCM,data:YNq9JEKsCPt5FkKDtI2QcfcQKcFUP/JJAE7e5um7XWtiSOkoSyMCoov1MAn9QbF87AQfKaZ8YNrP3oenIfQ0mzD6uYC0vGIRuyxK1SC3pNJdVq9G42V4inNbazGsaDWRealOALIe4KF8Az31Nl4azQJeI8EXxel+PFCMRcYE6sw=,iv:TJf5EH7cF+jYmf0AoUmUg//bUnuaOhofsoIzUhq0njE=,tag:88YTKMQn63dOOJkk2SrhTw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
Piped's playback is dead (see modules/piped.nix): YouTube's PoToken/SABR
enforcement defeats a NewPipeExtractor whose upstream has been dormant since
2026-05-29. Invidious is the candidate replacement, deployed side by side so
the two can be compared on the same subscriptions before anything is removed.

Corrects the earlier claim that Invidious is a fully-native replacement. It is
not. Since 2025 Invidious delegates all stream retrieval to invidious-companion,
which mints the po_token/visitor_data pair YouTube now requires; without it
search and subscriptions work and every video fails. nixpkgs' own module test
asserts that exact warning, and invidious-companion is not packaged in nixpkgs
(no package, no module option -- the assertion is the only hit in the tree), so
it runs as a container. services.invidious.sig-helper is the superseded
previous generation and is not a substitute.

The migration is therefore 4 containers -> 1, with the app and its database
becoming native services. The real argument is maintenance, not purity: the
piped-backend image was built 2026-03-26, the companion image 2026-08-01.

- native services.invidious on :3000 with a native PostgreSQL 17 (peer auth
  over the unix socket, no password anywhere)
- invidious-companion container on 127.0.0.1:8282 with upstream's hardening;
  no public_url, so Invidious proxies it and only one vhost is exposed
- the shared 16-char key comes from ONE sops secret rendered through two
  templates, so the JSON Invidious reads and the env the container reads
  cannot drift apart
- delivered to Invidious via LoadCredential, not a group-readable file: the
  upstream unit runs DynamicUser + PrivateUsers, under which a host
  supplementary group does not map into the service's user namespace
- external_port/https_only set by hand since nginx.enable is off; they are
  mandatory behind a reverse proxy or absolute URLs point at :3000
- default_home moved off Popular, which is a dead page here since
  popular_enabled is false
- Caddy vhost gets flush_interval -1 for the same MSE-timeout reason as
  piped-proxy, since video streams through this vhost

Verified on deploy: 9 of 10 sampled videos return 4 audio + 18-22 video
adaptive formats, and a real 256KiB ftypdash fragment pulls from googlevideo at
1.4MB/s. Piped returns audioStreams=0 on every video on the same day.

Piped is untouched -- all four containers still running. Exit criteria for
retiring it are in the module header.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
