### PR TITLE
feat(gatus): probe Invidious playback, not just its status code

### DIFF
--- a/modules/gatus.nix
+++ b/modules/gatus.nix
@@ -115,6 +115,53 @@ in
           alerts = [{ type = "ntfy"; }];
         }
 
+        # Invidious — availability, then a real playback probe.
+        #
+        # The availability check alone is close to worthless here: the way this
+        # service fails is companion's po_token going stale, after which the
+        # unit stays active, every page still renders, and only the stream URLs
+        # come back empty. That is the same "healthy while broken" shape as the
+        # alertmanager /alert 404 and the NUT /metrics path. So the probe below
+        # asserts on the streams themselves.
+        (mkHttp { name = "Invidious"; url = "https://invidious.theshire.io"; group = "Media"; })
+        {
+          name = "Invidious playback";
+          # Stable, not age- or region-restricted. If this video ever goes away
+          # the monitor will false-alarm — swap the ID, don't weaken the
+          # conditions.
+          url = "https://invidious.theshire.io/api/v1/videos/dQw4w9WgXcQ";
+          group = "Media";
+
+          # MUST stay above 10 minutes. src/invidious/videos.cr:298-317 only
+          # re-fetches from YouTube when the cached row is older than 10min;
+          # anything faster is answered from the `videos` table and would pass
+          # happily while live extraction is completely broken. 15m guarantees
+          # every run exercises the real companion path. (On a failed refresh
+          # Invidious deletes the cached row and re-raises, so there is no stale
+          # fallback to mask it.)
+          interval = "15m";
+
+          # Verified with a NEGATIVE test against a video that returns 200 with
+          # an empty body — [STATUS] PASSED while both body conditions FAILED
+          # (`len([BODY].adaptiveFormats) (0) > 10`). A status-only check, i.e.
+          # every other mkHttp in this file, calls that broken case healthy.
+          conditions = [
+            # Catches a hard failure: the API returns 500 + error_json when
+            # fetch_video raises "Invidious companion is not available".
+            "[STATUS] == 200"
+
+            # Status is NOT sufficient on its own — see the negative test above.
+            "len([BODY].adaptiveFormats) > 10"
+
+            # The actual Piped failure signature, encoded: video streams present
+            # but ZERO audio streams. A format list without any audio/* entry
+            # means nothing can play, and that is exactly what a dead extractor
+            # produces.
+            "[BODY] == pat(*audio/*)"
+          ];
+          alerts = [{ type = "ntfy"; }];
+        }
+
         # Observability
         (mkHttp { name = "Grafana";     url = "https://grafana.theshire.io";  group = "Observability"; })
         (mkHttp { name = "ntfy";        url = "https://ntfy.theshire.io";     group = "Observability"; })


### PR DESCRIPTION
Invidious fails in exactly the shape this repo keeps getting caught by: when
companion's po_token goes stale the unit stays active, every page still
renders, and only the stream URLs come back empty. A [STATUS] == 200 check --
which is what mkHttp gives every other HTTP endpoint here -- reports that as
healthy. Same class as the alertmanager /alert 404 and the NUT /metrics path.

So this asserts on the streams themselves:

  len([BODY].adaptiveFormats) > 10   non-empty format list
  [BODY] == pat(*audio/*)            at least one audio format

The second is the Piped failure signature encoded directly: video streams
present, zero audio streams, nothing playable.

Verified with a NEGATIVE test rather than by observing silence -- a throwaway
Gatus pointed at a video that returns 200 with an empty body:

  PASS  [STATUS] == 200
  FAIL  len([BODY].adaptiveFormats) (0) > 10
  FAIL  [BODY] () == pat(*audio/*)

Status passed on the broken case. Testing only for green cannot tell "working"
from "broken and mute".

interval is 15m and must stay above 10 minutes: src/invidious/videos.cr:298-317
only re-fetches from YouTube when the cached row is older than 10min, so a
faster probe is answered from the videos table and would pass while live
extraction is dead. On a failed refresh Invidious deletes the cached row and
re-raises, so there is no stale fallback masking it either.

No separate companion monitor: it is loopback-only on orthanc and unreachable
from Gatus on rivendell, and this probe covers it transitively -- if companion
dies, fetch_video raises and the API returns 500.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
