### PR TITLE
fix(caddy): allow the Range header through CORS so Invidious video plays

### DIFF
--- a/modules/caddy.nix
+++ b/modules/caddy.nix
@@ -126,7 +126,22 @@ in
           Access-Control-Allow-Credentials true
           Access-Control-Allow-Origin "${materialiousOrigin}"
           Access-Control-Allow-Methods "GET, POST, OPTIONS, HEAD, PATCH, PUT, DELETE"
-          Access-Control-Allow-Headers "User-Agent, Authorization, Content-Type"
+
+          # `Range` is REQUIRED and is not in upstream's documented header list.
+          # Invidious' DASH manifests use <SegmentBase> with indexRange and
+          # Initialization range, so every media fetch Shaka makes is a byte
+          # range request. Range is not a CORS-safelisted request header, so the
+          # browser preflights it — and without it listed here the preflight is
+          # rejected and NOTHING plays, while the rest of the UI works perfectly
+          # because plain API GETs are never preflighted. That asymmetry is what
+          # this looks like when it breaks: a completely functional site where
+          # every video fails.
+          Access-Control-Allow-Headers "User-Agent, Authorization, Content-Type, Range"
+
+          # Response headers are hidden from JS cross-origin unless exposed.
+          # Shaka reads Content-Range/Content-Length to size its buffers.
+          Access-Control-Expose-Headers "Content-Length, Content-Range, Accept-Ranges, Content-Type, Date"
+
           defer
         }
 


### PR DESCRIPTION
Materialious loaded and the whole UI worked, but no video would play, on
both iOS and desktop.

Invidious' DASH manifests use <SegmentBase> with indexRange and
Initialization range — 21 of them in a sampled manifest — so every media
fetch Shaka makes is a byte-range request. Range is not a CORS-safelisted
request header, so the browser preflights it, and Access-Control-Allow-
Headers did not list it. Every segment request failed at the preflight.

This is why the failure looked so odd: plain API GETs are never
preflighted, so search, subscriptions and the entire interface worked
perfectly while every video failed. Upstream's documented header list
(User-Agent, Authorization, Content-Type) is simply incomplete for the
media path.

Also adds Access-Control-Expose-Headers — cross-origin response headers
are hidden from JS unless exposed, and Shaka reads Content-Range and
Content-Length to size its buffers.

Verified against a real caddy binary: the preflight for
`Access-Control-Request-Headers: range` now returns Range in the allowed
list, and expose-headers are present on range responses.

Note curl could not catch this: it sends Range directly without a
preflight, so the earlier verification passed while browsers failed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
