### PR TITLE
feat(materialious): serve the app and the Invidious API from one origin

### DIFF
--- a/caddy8.log
+++ b/caddy8.log
@@ -1,0 +1,1 @@
+nohup: failed to run command 'run': No such file or directory

--- a/modules/caddy.nix
+++ b/modules/caddy.nix
@@ -36,19 +36,26 @@ let
     ${tlsConfig}
   '';
 
-  # Serve a static site out of the Nix store. try_files sends unknown paths to
-  # index.html because these are client-side-routed SPAs — without it a reload
-  # on any route but / is a 404.
-  static = root: ''
-    root * ${root}
-    try_files {path} /index.html
-    file_server
-    ${tlsConfig}
-  '';
-
-  # Origin allowed to make cross-origin API calls to Invidious. See the CORS
-  # section in modules/materialious.nix.
+  # Origin allowed to make cross-origin API calls to Invidious. Retained only
+  # for the stock Invidious UI's vhost — yt.theshire.io no longer makes any
+  # cross-origin request. See the CORS note on that vhost below.
   materialiousOrigin = "https://yt.theshire.io";
+
+  # The Invidious paths Materialious actually touches, proxied under
+  # yt.theshire.io so the browser never leaves that origin. Derived from
+  # Invidious' own route table (src/invidious/routing.cr) intersected with what
+  # Materialious calls — NOT guessed:
+  #   /api          v1 endpoints + /api/manifest/dash (the DASH manifest)
+  #   /companion    where /api/manifest 302s to; carries the media bytes
+  #   /vi /ggpht    thumbnail and channel-avatar proxies
+  #   /sb           storyboard images
+  #   /authorize_token /login   the Invidious OAuth-ish flow (src/lib/auth.ts:81)
+  #
+  # None of these collide with a Materialious client route — note it uses
+  # /internal/login, not /login. Invidious owns far more top-level paths than
+  # these (/watch, /channel, /search, /feed...), and those deliberately stay
+  # with Materialious; it does not need Invidious' HTML pages at all.
+  invidiousPaths = "/api/* /companion/* /vi/* /ggpht/* /sb/* /authorize_token /login";
 in
 
 {
@@ -151,10 +158,36 @@ in
         ${tlsConfig}
       '';
 
-      # Materialious — static SPA built by modules/materialious.nix and served
-      # straight from the store; there is no backend process for this vhost.
-      # It talks to invidious.theshire.io above from the browser.
-      "yt.theshire.io".extraConfig               = static "${pkgs.materialious}";
+      # Materialious — static SPA built by modules/materialious.nix, served
+      # straight from the store, PLUS a reverse proxy for the handful of
+      # Invidious paths it calls.
+      #
+      # Everything on ONE origin, deliberately. Serving the app and the API from
+      # two hostnames made every media fetch a cross-origin request, which cost
+      # a CORS preflight per byte-range and made the traffic look like a public
+      # page reaching into RFC1918 space — something privacy extensions treat as
+      # hostile. Same origin means no preflight, no CORS headers, and nothing
+      # third-party to inspect. See the header of modules/materialious.nix.
+      #
+      # try_files sends unknown paths to index.html because this is a
+      # client-side-routed SPA; without it a reload on any route but / 404s.
+      # The handle blocks are mutually exclusive and evaluated in order, so the
+      # proxy wins for Invidious paths and the SPA catches everything else.
+      "yt.theshire.io".extraConfig               = ''
+        @invidious path ${invidiousPaths}
+        handle @invidious {
+          reverse_proxy orthanc.home.theshire.io:3000 {
+            flush_interval -1
+          }
+        }
+
+        handle {
+          root * ${pkgs.materialious}
+          try_files {path} /index.html
+          file_server
+        }
+        ${tlsConfig}
+      '';
 
       # pirateship backends
       "stream.theshire.io".extraConfig           = proxy "pirateship.home.theshire.io:4533";

--- a/modules/materialious.nix
+++ b/modules/materialious.nix
@@ -69,14 +69,34 @@
 # UI, and this makes it load-bearing for both.
 #
 # -----------------------------------------------------------------------------
-# CORS
+# SAME ORIGIN — no CORS, by construction
 #
-# The browser loads the app from yt.theshire.io and calls the API on
-# invidious.theshire.io — two origins, so Invidious' vhost has to return CORS
-# headers. Invidious has no setting for this, so it is done in the reverse
-# proxy; see the CORS block on invidious.theshire.io in modules/caddy.nix. The
-# allowed origin is pinned to this vhost, not `*`, because the responses are
-# sent with credentials.
+# Caddy serves this app AND proxies the Invidious paths it calls under the one
+# hostname (modules/caddy.nix), so the browser never makes a cross-origin
+# request. VITE_DEFAULT_INVIDIOUS_INSTANCE therefore points at yt.theshire.io,
+# not at the Invidious vhost.
+#
+# This replaced a two-origin setup that needed CORS headers on Invidious'
+# vhost, and it fixed more than tidiness:
+#
+#   - No preflight. DASH here is <SegmentBase>, so every media fetch is a byte
+#     range request, and `Range` is not CORS-safelisted — each one cost an
+#     extra OPTIONS round trip. Getting that header list wrong was also a
+#     silent, total playback failure while the rest of the UI worked perfectly.
+#   - Nothing third-party to inspect. A page on a public-suffix domain fetching
+#     from another host that resolves into RFC1918 space is, to a privacy
+#     extension, indistinguishable from a site probing your LAN. First-party
+#     requests get none of that treatment.
+#
+# The stock Invidious UI at invidious.theshire.io is untouched and still works
+# as the control for the Invidious trial. Its vhost keeps a CORS block that
+# nothing needs any more; it is left in place for one release as a rollback
+# path and should be deleted once this is settled.
+#
+# CONSEQUENCE ON FIRST DEPLOY: the Invidious session cookie is per-origin, so a
+# signed-in user must authorise once more under this hostname. The token itself
+# is held client-side by Materialious (src/lib/auth.ts), not read from a cookie,
+# so nothing else about the flow changes.
 #
 # -----------------------------------------------------------------------------
 # UPGRADING (manual — Renovate's custom manager only matches container images)
@@ -218,7 +238,11 @@ let
       # blob into the bundle with no error anywhere. The installCheck below
       # exists specifically to catch that regression.
       cat > .env <<'EOF'
-      VITE_DEFAULT_INVIDIOUS_INSTANCE=https://invidious.theshire.io
+      # ITS OWN ORIGIN, not invidious.theshire.io. Caddy proxies the Invidious
+      # paths under this same hostname (see modules/caddy.nix), so every request
+      # the browser makes is first-party. Pointing this at the Invidious vhost
+      # is what created the cross-origin problems described in the header.
+      VITE_DEFAULT_INVIDIOUS_INSTANCE=https://yt.theshire.io
 
       # Deliberately EMPTY — see the companion section in the header comment.
       # Setting this would require exposing companion publicly.


### PR DESCRIPTION
Materialious was served from yt.theshire.io while calling the Invidious
API on invidious.theshire.io. Caddy now proxies the handful of Invidious
paths the app touches under yt.theshire.io itself, and the app is pointed
at its own origin, so the browser never makes a cross-origin request.

Motivated by a playback stall that only reproduces in Firefox with
uBlock Origin enabled: requests stop entirely for 10-40s, nothing
pending and nothing failed, then everything resumes and playback starts
immediately. It is not uBO's filtering — trusting the sites (confirmed
present in trustedset) and disabling CNAME uncloaking both changed
nothing, and the logger shows no blocked request. It could not be
reproduced here across 18 runs on the affected videos, with and without
uBO 1.72.2 and the same stock filter lists.

This is therefore an informed bet rather than a diagnosis: a page on a
public-suffix domain fetching from another host that resolves into
RFC1918 space is, to a privacy extension, indistinguishable from a site
probing the LAN. First-party requests get none of that treatment.

It is worth doing regardless:
  - No CORS preflight. DASH here is <SegmentBase>, so every media fetch
    is a byte-range request and Range is not CORS-safelisted; each one
    cost an extra OPTIONS round trip.
  - No CORS headers to get wrong. Omitting Range from the allowed list
    was a total, silent playback failure while the whole UI worked.

Path split derived from Invidious' route table intersected with what
Materialious actually calls, not guessed: /api, /companion, /vi, /ggpht,
/sb, /authorize_token, /login. None collide with a Materialious client
route (it uses /internal/login, not /login). Invidious' many other
top-level paths — /watch, /channel, /search, /feed — stay with the SPA,
which does not need Invidious' HTML pages at all.

Verified against a real caddy binary: all 8 Invidious paths proxy, and
/, /watch/<id>, /internal/login and /search all fall through to
index.html.

The stock Invidious UI is untouched and remains the control for the
Invidious trial. Its now-unnecessary CORS block is deliberately left in
place for one release as a rollback path.

Consequence on first deploy: the Invidious session cookie is per-origin,
so a signed-in user must authorise once more under this hostname.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
