### PR TITLE
fix(materialious): derive the instance-URL assertion from the value itself

### DIFF
--- a/modules/materialious.nix
+++ b/modules/materialious.nix
@@ -112,6 +112,12 @@
 { pkgs, lib, ... }:
 
 let
+  # ONE definition, used both to bake the value in and to assert it landed.
+  # These were two independent literals and they drifted the moment the origin
+  # changed: the build then failed on its own stale assertion. The check is only
+  # worth having if it cannot disagree with the thing it checks.
+  instanceUrl = "https://yt.theshire.io";
+
   materialious = pkgs.buildNpmPackage rec {
     pname = "materialious";
     version = "1.17.6";
@@ -242,7 +248,7 @@ let
       # paths under this same hostname (see modules/caddy.nix), so every request
       # the browser makes is first-party. Pointing this at the Invidious vhost
       # is what created the cross-origin problems described in the header.
-      VITE_DEFAULT_INVIDIOUS_INSTANCE=https://yt.theshire.io
+      VITE_DEFAULT_INVIDIOUS_INSTANCE=${instanceUrl}
 
       # Deliberately EMPTY — see the companion section in the header comment.
       # Setting this would require exposing companion publicly.
@@ -280,8 +286,8 @@ let
     installCheckPhase = ''
       runHook preInstallCheck
 
-      grep -rq 'invidious\.theshire\.io' $out/_app \
-        || { echo "FAIL: Invidious instance URL was not baked into the bundle"; exit 1; }
+      grep -rqF '${instanceUrl}' $out/_app \
+        || { echo "FAIL: instance URL ${instanceUrl} was not baked into the bundle"; exit 1; }
 
       if grep -rq 'VITE_DEFAULT_[A-Z_]*_PLACEHOLDER' $out; then
         echo "FAIL: unsubstituted upstream placeholder left in the bundle"; exit 1


### PR DESCRIPTION
The same-origin change moved the instance to yt.theshire.io but left the
installCheckPhase grepping for invidious.theshire.io, so the build failed
on its own stale assertion:

  FAIL: Invidious instance URL was not baked into the bundle

The check did exactly what it exists to do — it failed loudly at build
time rather than shipping a bundle pointing at the wrong host — but it
should not have been possible for the two to disagree. The URL is now a
single let-binding used both to write .env and to assert the result, so
the assertion cannot drift from the value again.

Also switches the grep to -F: the old pattern was a regex whose
unescaped dots matched any character.

Verified by building with the corrected check: installCheck OK.

Nothing was deployed — the build failed before activation, so rivendell
never left the previous generation.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
