### PR TITLE
fix(caddy): proxy /videoplayback and /latest_version on the yt vhost

### DIFF
--- a/modules/caddy.nix
+++ b/modules/caddy.nix
@@ -50,13 +50,24 @@ let
   #   /companion    where /api/manifest 302s to; carries the media bytes
   #   /vi /ggpht    thumbnail and channel-avatar proxies
   #   /sb           storyboard images
+  #   /videoplayback  what adaptiveFormats[].url points at
+  #   /latest_version the non-DASH/progressive media endpoint
+  #   /download     "download this video"
   #   /authorize_token /login   the Invidious OAuth-ish flow (src/lib/auth.ts:81)
+  #
+  # /videoplayback and /latest_version are NOT optional now that Invidious'
+  # `domain` is this vhost: every URL in adaptiveFormats is absolute and points
+  # here. Miss one of these and it falls through to the SPA fallback below,
+  # which answers with index.html and HTTP 200 — a broken stream that looks
+  # like a successful request.
   #
   # None of these collide with a Materialious client route — note it uses
   # /internal/login, not /login. Invidious owns far more top-level paths than
   # these (/watch, /channel, /search, /feed...), and those deliberately stay
   # with Materialious; it does not need Invidious' HTML pages at all.
-  invidiousPaths = "/api/* /companion/* /vi/* /ggpht/* /sb/* /authorize_token /login";
+  invidiousPaths =
+    "/api/* /companion/* /vi/* /ggpht/* /sb/* /videoplayback /latest_version "
+    + "/download /authorize_token /login";
 in
 
 {


### PR DESCRIPTION
With Invidious' `domain` now set to yt.theshire.io, every absolute URL it
emits points at that vhost — including adaptiveFormats[].url, which is
https://yt.theshire.io/videoplayback?... Neither /videoplayback nor
/latest_version was in the proxied path list, so both would have fallen
through to the SPA fallback and been answered with index.html and HTTP
200: a broken stream that looks like a successful request.

Caught by reading the API output after deploying orthanc, before
deploying rivendell — so it never reached a running config.

/download added for the same reason. Path list cross-checked against
Invidious' route table for anything that serves media or assets rather
than HTML.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
