### PR TITLE
feat(monitoring): VPN leak detection + close the ad-blocking blind spots

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -163,6 +163,7 @@
           ./modules/music-sync.nix
           ./modules/navidrome.nix
           ./modules/qbittorrent-seed-policy.nix
+          ./modules/vpn-killswitch.nix
         ];
         specialArgs = { inherit inputs nixos-raspberrypi r2AccountId brianSshKey; };
       };

--- a/modules/gatus.nix
+++ b/modules/gatus.nix
@@ -40,6 +40,40 @@ let
     conditions = [ "[DNS_RCODE] == NOERROR" ];
     alerts = [{ type = "ntfy"; }];
   };
+
+  # Ad-blocking canary — the only end-to-end test of whether blocking WORKS.
+  #
+  # Every other signal is a proxy. `blocky_denylist_cache_entries` counts what
+  # was loaded, and on 2026-08-01 it counted 216113 entries while
+  # pagead2.googlesyndication.com resolved perfectly happily: the list had
+  # loaded, it just used bare entries, which Blocky 0.34 matches as exact names
+  # only. Entry-count alerting is structurally incapable of catching that class
+  # of bug. Asking the resolver the question a client would ask is.
+  #
+  # This catches, in one check: empty lists, wrong matching semantics, blocking
+  # switched off, a bad upstream, and the service being down.
+  #
+  # For A queries Gatus puts the resolved address in [BODY] (client.QueryDNS,
+  # `case dns.TypeA`), and Blocky answers a blocked name with 0.0.0.0 NOERROR
+  # — verified against both resolvers rather than assumed.
+  #
+  # The canary is a subdomain on purpose: an apex would pass even under the
+  # bare-entry bug that prompted this. Ad-serving hosts are subdomains, so the
+  # test should be one too.
+  mkAdBlockCanary = { name, host, group }: {
+    inherit name group;
+    url = "${host}:53";
+    dns = {
+      "query-name" = "pagead2.googlesyndication.com";
+      "query-type" = "A";
+    };
+    interval = "5m";
+    conditions = [
+      "[DNS_RCODE] == NOERROR"
+      "[BODY] == 0.0.0.0"
+    ];
+    alerts = [{ type = "ntfy"; }];
+  };
 in
 
 {
@@ -70,17 +104,27 @@ in
         (mkDns { name = "mirkwood DNS"; host = "mirkwood"; group = "Infrastructure"; })
         (mkDns { name = "rivendell DNS"; host = "rivendell"; group = "Infrastructure"; })
 
+        (mkAdBlockCanary { name = "mirkwood ad blocking";  host = "mirkwood";  group = "Infrastructure"; })
+        (mkAdBlockCanary { name = "rivendell ad blocking"; host = "rivendell"; group = "Infrastructure"; })
+
         # Home
         (mkHttp { name = "Homepage";       url = "https://homepage.theshire.io"; group = "Home"; })
         (mkHttp { name = "Home Assistant"; url = "https://ha.theshire.io";   group = "Home"; })
 
         # Media
         (mkHttp { name = "Jellyfin";    url = "https://jellyfin.theshire.io"; group = "Media"; })
-        # TCP check on gluetun's control port — all arr container ports (including qBT's
-        # 9091) live in gluetun's network namespace, so this is the right signal for
-        # "VPN container is up and the media stack has network". Complements the Caddy-
-        # proxied qBittorrent check below with a direct LAN path that doesn't depend on
-        # Caddy or external DNS.
+        # TCP check on gluetun's control port. This is a LIVENESS check for the
+        # container and nothing more — it is NOT a tunnel check, despite the name.
+        # gluetun's control server listens on `:::8000` inside the netns and does
+        # not touch tun0, so this stays green with the VPN completely down.
+        # Measured 2026-08-02; the control server's status routes would answer the
+        # real question but every one of them returns `Unauthorized` (gluetun now
+        # requires an auth config, and /var/lib/gluetun/auth/config.toml is empty).
+        #
+        # Whether the tunnel is actually up, and whether anything is escaping it,
+        # is answered by vpn-leak-check on pirateship — see modules/vpn-killswitch.nix
+        # and the `vpn` alert group in modules/grafana.nix. Keep this check for what
+        # it is good at: a direct LAN path that does not depend on Caddy or DNS.
         {
           name = "gluetun VPN";
           url = "tcp://pirateship:8000";

--- a/modules/grafana.nix
+++ b/modules/grafana.nix
@@ -208,6 +208,127 @@ let
               description = "{{ $labels.instance }} has only {{ $value }} entries in the 'malware' denylist (expected ~2.16M). Malware/phishing blocking is effectively off — check `journalctl -u blocky` for list download failures.";
             };
           }
+          {
+            # Early warning, and the one that would actually have caught the
+            # 2026-07-31 outage AT THE TIME. The entry-count alerts above are
+            # lagging indicators: they only fire once a list has already
+            # collapsed, which on that occasion meant after a restart, ~1.5 days
+            # in. This counter increments on the very first failed download —
+            # 02:31 on the day it broke.
+            #
+            # It also covers the case the entry counts structurally cannot see:
+            # when a REFRESH fails for an already-loaded list, Blocky keeps
+            # serving the previous copy. Entries stay at ~216k and look perfect
+            # while the lists quietly rot.
+            alert = "BlocklistDownloadFailing";
+            expr = ''increase(blocky_failed_downloads_total[1h]) > 0'';
+            "for" = "15m";
+            labels.severity = "warning";
+            annotations = {
+              summary = "Blocky blocklist downloads are failing on {{ $labels.instance }}";
+              description = "{{ $labels.instance }} recorded {{ $value }} failed blocklist download(s) in the last hour. The in-memory lists may still be serving, so blocking is probably still working right now — but it is going stale. Check `journalctl -u blocky | grep -i 'download\\|status code'`.";
+            };
+          }
+          {
+            # The staleness backstop. Blocky refreshes every 4h by default; if
+            # every refresh fails it keeps the old list forever and no other
+            # metric here changes. 9h is two missed cycles plus slack, so a
+            # single transient failure stays quiet.
+            alert = "BlocklistStale";
+            expr = ''time() - blocky_last_list_group_refresh_timestamp_seconds > 32400'';
+            "for" = "30m";
+            labels.severity = "warning";
+            annotations = {
+              summary = "Blocky blocklists have not refreshed on {{ $labels.instance }}";
+              description = "{{ $labels.instance }} last refreshed its blocklists {{ $value | humanizeDuration }} ago (refresh period is 4h). The lists still loaded are being served but are no longer being updated.";
+            };
+          }
+        ];
+      }
+      {
+        # ---------------------------------------------------------------------
+        # VPN — see modules/vpn-killswitch.nix for why these metrics exist and
+        # why none of the pre-existing checks could see a tunnel failure.
+        #
+        # These read textfile-collector metrics written by vpn-leak-check on
+        # pirateship, so they arrive through the `node` job, not a job of their
+        # own. That means an absent metric shows up as "no series" rather than a
+        # down target — hence VpnLeakCheckStale, which is the only rule here
+        # that can distinguish "no leaks" from "nothing is looking".
+        # ---------------------------------------------------------------------
+        name = "vpn";
+        rules = [
+          {
+            # The stack has already stopped itself by the time this fires. This
+            # is notification, not detection — but it repeats daily via
+            # Alertmanager's repeat_interval, so a latched stack cannot be
+            # forgotten about the way a single ntfy push can be missed.
+            alert = "VpnKillSwitchTripped";
+            expr = ''vpn_killswitch_tripped == 1'';
+            "for" = "0m";
+            labels.severity = "critical";
+            annotations = {
+              summary = "arr stack latched OFF after a confirmed VPN leak";
+              description = "pirateship stopped the entire arr stack because traffic was escaping the VPN. It will not restart until the latch is cleared: `cat /var/lib/vpn-killswitch/tripped` for the reason, then `sudo rm /var/lib/vpn-killswitch/tripped && sudo systemctl start podman-gluetun`.";
+            };
+          }
+          {
+            # Fires independently of the latch, so a leak is still reported even
+            # if the automatic stop failed (podman wedged, systemctl refused).
+            # Never rely solely on the actuator to tell you the actuator ran.
+            alert = "VpnEgressLeak";
+            expr = ''vpn_egress_matches_host == 1'';
+            "for" = "0m";
+            labels.severity = "critical";
+            annotations = {
+              summary = "arr stack traffic is leaving via the home IP";
+              description = "The gluetun netns reported the same public IP as pirateship itself — traffic is bypassing the tunnel. If the stack is still running, stop it now: `sudo systemctl stop podman-gluetun`.";
+            };
+          }
+          {
+            # Config drift, not runtime failure. 10m because a gluetun restart
+            # briefly has no rules loaded while it rebuilds them.
+            alert = "VpnFirewallDegraded";
+            expr = ''vpn_firewall_intact == 0'';
+            "for" = "10m";
+            labels.severity = "critical";
+            annotations = {
+              summary = "gluetun kill-switch firewall is not in its expected shape";
+              description = "Either the OUTPUT policy is no longer DROP, or an egress rule permits a destination outside the declared allowlist. Nothing may be leaking yet — the enforcement that would stop it is what has weakened. See `journalctl -u vpn-leak-check` and modules/vpn-killswitch.nix.";
+            };
+          }
+          {
+            # Warning, not critical: a dead tunnel is the kill switch working.
+            # Nothing is at risk, the media stack is simply useless. 20m rides
+            # out ProtonVPN server rotations and the gluetun-watchdog's own
+            # 15m/30m restart cycle without duplicating its notification.
+            alert = "VpnTunnelDown";
+            expr = ''vpn_tunnel_up == 0 and vpn_killswitch_tripped == 0'';
+            "for" = "20m";
+            labels.severity = "warning";
+            annotations = {
+              summary = "arr stack VPN tunnel has been down for 20m";
+              description = "The gluetun netns cannot reach the internet. This is fail-closed — nothing is leaking — but downloads are stalled. Check `journalctl -u podman-gluetun` and `journalctl -u gluetun-watchdog`.";
+            };
+          }
+          {
+            # The dead-man's switch on the detector itself. Without this, a
+            # vpn-leak-check that stopped running is indistinguishable from a
+            # network with no leaks — the exact failure shape that let the
+            # blocklist outage run for a day and a half.
+            #
+            # `absent()` covers the metric never having existed at all (unit
+            # never ran, textfile dir missing); the time comparison covers it
+            # having stopped. Both are needed: neither catches the other.
+            alert = "VpnLeakCheckStale";
+            expr = ''absent(vpn_leak_check_timestamp_seconds) or (time() - vpn_leak_check_timestamp_seconds > 1800)'';
+            "for" = "10m";
+            labels.severity = "warning";
+            annotations = {
+              summary = "VPN leak detector has stopped reporting";
+              description = "vpn-leak-check on pirateship has not published a result in over 30m (it runs every 5m). The VPN kill switch is unmonitored — the other vpn alerts are silent because nothing is looking, not because nothing is wrong. Check `systemctl status vpn-leak-check.timer`.";
+            };
+          }
         ];
       }
       {

--- a/modules/grafana.nix
+++ b/modules/grafana.nix
@@ -269,7 +269,7 @@ let
             labels.severity = "critical";
             annotations = {
               summary = "arr stack latched OFF after a confirmed VPN leak";
-              description = "pirateship stopped the entire arr stack because traffic was escaping the VPN. It will not restart until the latch is cleared: `cat /var/lib/vpn-killswitch/tripped` for the reason, then `sudo rm /var/lib/vpn-killswitch/tripped && sudo systemctl start podman-gluetun`.";
+              description = "pirateship stopped the entire arr stack because traffic was escaping the VPN. It will not restart until the latch is cleared. Read the reason with `cat /var/lib/vpn-killswitch/tripped`, then `sudo rm /var/lib/vpn-killswitch/tripped && sudo systemctl start podman-gluetun podman-qbittorrent podman-sabnzbd podman-radarr podman-sonarr podman-prowlarr podman-lidarr` — starting gluetun alone does not bring the consumers back.";
             };
           }
           {

--- a/modules/vpn-killswitch.nix
+++ b/modules/vpn-killswitch.nix
@@ -1,0 +1,269 @@
+# modules/vpn-killswitch.nix — leak detector + hard latch for the arr stack VPN
+#
+# gluetun already IS a kill switch: iptables OUTPUT policy DROP with eth0
+# permitted only for the podman bridge, the WireGuard endpoint, and the single
+# /32 LAN exception. If tun0 dies, packets route to a dead interface and are
+# dropped. Verified 2026-08-02 — see modules/arr-stack.nix and the
+# gluetun-lan-exception notes.
+#
+# What was missing is not enforcement, it is DETECTION. Every existing check
+# around this stack is blind to the tunnel:
+#
+#   * Gatus "gluetun VPN" is a bare TCP connect to pirateship:8000. The control
+#     server listens on `:::8000` inside the netns and does not depend on tun0
+#     at all, so that check stays green with the tunnel completely down.
+#   * The Gatus HTTP checks (qBittorrent/Radarr/...) hit web UIs that bind
+#     inside the netns and are reached over the podman bridge — also tun0
+#     independent, also green.
+#   * `UnitFailed` cannot see it: gluetun retries internally and never exits.
+#   * `gluetun-watchdog` is the only thing that notices, and only indirectly
+#     (NAT-PMP port forwarding needs the tunnel). Its response is to RESTART,
+#     which is the right response to a dead tunnel and the wrong one to a
+#     leaking tunnel.
+#
+# So nothing here could distinguish "tunnel healthy" from "tunnel down" from
+# "traffic escaping", and nothing at all watched the firewall rules.
+#
+# DESIGN — trip only on a POSITIVE leak signal, never on absence of evidence.
+# A container that cannot reach the internet is the kill switch WORKING; that
+# must never trip the latch. Only two things count as a leak:
+#
+#   1. The netns reports a public IP equal to the host's public IP. That means
+#      packets left via eth0 carrying the home address, which is the actual
+#      harm being defended against.
+#   2. The gluetun firewall is not in its expected shape — OUTPUT policy is not
+#      DROP, or an eth0 ACCEPT rule names a destination outside the allowlist.
+#      This is the config-drift case (someone widens FIREWALL_OUTBOUND_SUBNETS,
+#      a future image changes defaults) which produces no symptom until it
+#      matters.
+#
+# Anything else — exec failure, timeout, empty answer — is UNKNOWN and is
+# reported as such, never acted on. Two consecutive bad verdicts are required
+# before tripping so a single bad read cannot take the stack down.
+#
+# ON TRIP the whole stack is stopped and LATCHED OFF. The latch is a file, and
+# podman-gluetun gets an ExecStartPre that refuses to start while it exists —
+# so a reboot, a deploy, or the 05:00 auto-upgrade cannot quietly bring the
+# stack back up with an unexplained leak still in place. That is deliberate:
+# "disabled until troubleshooting happens" means a human has to clear it.
+#
+#   Clear with:  sudo rm /var/lib/vpn-killswitch/tripped
+#                sudo systemctl start podman-gluetun
+#
+# Metrics go to node_exporter's textfile collector (modules/monitoring.nix) and
+# are alerted on in the `vpn` rule group in modules/grafana.nix. The staleness
+# metric matters as much as the leak metric: without it, a detector that
+# silently died looks exactly like a network with no leaks.
+
+{ config, pkgs, lib, ... }:
+
+let
+  stateDir   = "/var/lib/vpn-killswitch";
+  latchFile  = "${stateDir}/tripped";
+  metricFile = "/var/lib/prometheus-textfiles/vpn_killswitch.prom";
+  ntfyUrl    = "http://10.0.1.9:2586/homelab";
+
+  # Every container sharing gluetun's netns, plus gluetun itself. Order matters
+  # on stop: drop the consumers before the tunnel they ride on.
+  stackUnits = [
+    "podman-qbittorrent" "podman-sabnzbd"  "podman-radarr"
+    "podman-sonarr"      "podman-prowlarr" "podman-lidarr"
+    "podman-gluetun"
+  ];
+
+  # The only destination-scoped OUTPUT ACCEPTs gluetun is expected to have on
+  # eth0. Kept in sync by hand with FIREWALL_OUTBOUND_SUBNETS in arr-stack.nix
+  # — if you widen that, widen this too, and understand that doing so is the
+  # exact thing this check exists to catch.
+  allowedOutboundDests = [ "10.88.0.0/16" "10.0.1.10/32" ];
+in
+{
+  systemd.services.vpn-leak-check = {
+    description = "Verify the arr stack VPN is not leaking; latch the stack off if it is";
+    after = [ "podman-gluetun.service" "network-online.target" ];
+    wants = [ "network-online.target" ];
+
+    path = with pkgs; [ podman curl coreutils gnugrep gawk systemd ];
+
+    serviceConfig = {
+      Type = "oneshot";
+      StateDirectory = "vpn-killswitch";
+    };
+
+    # Deliberately NOT `set -e`: a probe that fails must fall through to the
+    # UNKNOWN path and still publish metrics, not abort the unit. Unit failure
+    # here would make UnitFailed fire on every transient network blip.
+    script = ''
+      set -uo pipefail
+
+      LATCH="${latchFile}"
+      STRIKE_FILE="${stateDir}/strikes"
+
+      write_metrics() {
+        # $1 tripped  $2 tunnel_up  $3 egress_matches_host  $4 firewall_intact
+        [ -d /var/lib/prometheus-textfiles ] || return 0
+        tmp=$(mktemp -p /var/lib/prometheus-textfiles) || return 0
+        {
+          printf '# HELP vpn_killswitch_tripped Arr stack latched off after a confirmed VPN leak\n'
+          printf '# TYPE vpn_killswitch_tripped gauge\n'
+          printf 'vpn_killswitch_tripped %s\n' "$1"
+          printf '# HELP vpn_tunnel_up The gluetun netns can reach the internet\n'
+          printf '# TYPE vpn_tunnel_up gauge\n'
+          printf 'vpn_tunnel_up %s\n' "$2"
+          printf '# HELP vpn_egress_matches_host Netns public IP equals the host public IP (a leak)\n'
+          printf '# TYPE vpn_egress_matches_host gauge\n'
+          printf 'vpn_egress_matches_host %s\n' "$3"
+          printf '# HELP vpn_firewall_intact gluetun OUTPUT policy is DROP and the egress allowlist is unwidened\n'
+          printf '# TYPE vpn_firewall_intact gauge\n'
+          printf 'vpn_firewall_intact %s\n' "$4"
+          printf '# HELP vpn_leak_check_timestamp_seconds Unix time of the last completed leak check\n'
+          printf '# TYPE vpn_leak_check_timestamp_seconds gauge\n'
+          printf 'vpn_leak_check_timestamp_seconds %s\n' "$(date +%s)"
+        } > "$tmp"
+        chmod 0644 "$tmp"
+        mv "$tmp" "${metricFile}"
+      }
+
+      # Already latched: publish the state and stop. Do not re-probe, do not
+      # re-notify — the stack is down and a human owes it a look.
+      if [ -e "$LATCH" ]; then
+        write_metrics 1 0 0 0
+        exit 0
+      fi
+
+      # ---- probe 1: does the netns egress from an address that is not ours? --
+      # Both probes hit the same service so the two answers are comparable. The
+      # host probe takes the normal path; the netns probe must traverse tun0 or
+      # it cannot answer at all.
+      HOST_IP=$(curl -s --max-time 15 https://api.ipify.org 2>/dev/null || true)
+      NS_IP=$(timeout 25 podman exec gluetun \
+                wget -qO- -T 15 https://api.ipify.org 2>/dev/null || true)
+
+      # ---- probe 2: is the firewall still shaped the way we think? ----------
+      FW_RULES=$(timeout 15 podman exec gluetun iptables -S OUTPUT 2>/dev/null || true)
+
+      TUNNEL_UP=0
+      LEAK=0
+      FW_INTACT=1
+      REASON=""
+
+      if [ -n "$NS_IP" ]; then
+        TUNNEL_UP=1
+        if [ -n "$HOST_IP" ] && [ "$NS_IP" = "$HOST_IP" ]; then
+          LEAK=1
+          REASON="netns egress IP $NS_IP equals the host public IP — traffic is leaving via eth0, NOT the tunnel"
+        fi
+      fi
+
+      # An unreadable ruleset is UNKNOWN, not a violation: podman exec can fail
+      # while the firewall is perfectly fine. Only a ruleset we can read and
+      # that disagrees with expectations counts against it.
+      if [ -n "$FW_RULES" ]; then
+        if ! printf '%s\n' "$FW_RULES" | grep -qx -- "-P OUTPUT DROP"; then
+          FW_INTACT=0
+          REASON="gluetun OUTPUT policy is not DROP — the kill switch is not enforcing"
+        fi
+
+        # Any destination-scoped ACCEPT out eth0 must name an allowed target.
+        # Rules with no -d (lo, conntrack, tun0) are not destination-scoped and
+        # are excluded by the -o eth0 filter plus the empty-dest skip.
+        while read -r rule; do
+          [ -z "$rule" ] && continue
+          dest=$(printf '%s\n' "$rule" | awk '{for(i=1;i<=NF;i++) if($i=="-d") print $(i+1)}')
+          [ -z "$dest" ] && continue
+          # The WireGuard endpoint /32 is legitimate and changes on every server
+          # rotation, so it is identified by shape (udp dport 51820) rather than
+          # by address.
+          printf '%s\n' "$rule" | grep -q -- "--dport 51820" && continue
+          ok=0
+          for allowed in ${lib.concatStringsSep " " allowedOutboundDests}; do
+            [ "$dest" = "$allowed" ] && ok=1
+          done
+          if [ "$ok" -eq 0 ]; then
+            FW_INTACT=0
+            REASON="unexpected egress permitted to $dest — the gluetun firewall has been widened beyond the declared allowlist"
+          fi
+        done < <(printf '%s\n' "$FW_RULES" | grep -- "-j ACCEPT" | grep -- "-o eth0")
+      fi
+
+      VERDICT_BAD=0
+      if [ "$LEAK" -eq 1 ] || [ "$FW_INTACT" -eq 0 ]; then VERDICT_BAD=1; fi
+
+      # ---- two-strike confirmation ------------------------------------------
+      # One bad read must not take down the media stack; two consecutive ones
+      # five minutes apart are not a transient.
+      STRIKES=$(cat "$STRIKE_FILE" 2>/dev/null || echo 0)
+      if [ "$VERDICT_BAD" -eq 1 ]; then
+        STRIKES=$(( STRIKES + 1 ))
+      else
+        STRIKES=0
+      fi
+      echo "$STRIKES" > "$STRIKE_FILE"
+
+      write_metrics 0 "$TUNNEL_UP" "$LEAK" "$FW_INTACT"
+
+      if [ "$VERDICT_BAD" -eq 1 ] && [ "$STRIKES" -ge 2 ]; then
+        echo "VPN LEAK CONFIRMED: $REASON" >&2
+        printf '%s\n%s\n' "$(date -Is)" "$REASON" > "$LATCH"
+
+        for unit in ${lib.concatStringsSep " " stackUnits}; do
+          systemctl stop "$unit" || true
+        done
+
+        write_metrics 1 0 "$LEAK" "$FW_INTACT"
+
+        curl -s --connect-timeout 5 --max-time 30 --retry 3 --retry-delay 10 \
+          --retry-all-errors \
+          -H 'Title: VPN LEAK - arr stack disabled' \
+          -H 'Priority: 5' \
+          -H 'Tags: rotating_light' \
+          -d "pirateship: $REASON
+
+The arr stack has been STOPPED and latched off. It will not restart on reboot,
+deploy or auto-upgrade until the latch is cleared:
+
+  sudo rm ${latchFile}
+  sudo systemctl start podman-gluetun" \
+          "${ntfyUrl}" || true
+      elif [ "$VERDICT_BAD" -eq 1 ]; then
+        echo "Possible VPN leak (strike $STRIKES/2): $REASON" >&2
+      fi
+
+      exit 0
+    '';
+  };
+
+  systemd.timers.vpn-leak-check = {
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnBootSec = "3min";
+      OnUnitActiveSec = "5min";
+      AccuracySec = "30s";
+    };
+  };
+
+  # The latch. podman-gluetun refuses to start while the file exists, and every
+  # arr container has Requires=podman-gluetun.service, so the whole stack stays
+  # down with it. Failing here also trips the existing UnitFailed alert, which
+  # is the intended noise level for "your VPN leaked".
+  systemd.services.podman-gluetun.serviceConfig.ExecStartPre = lib.mkBefore [
+    "${pkgs.writeShellScript "vpn-killswitch-latch" ''
+      if [ -e "${latchFile}" ]; then
+        echo "REFUSING TO START: the VPN kill switch is latched." >&2
+        echo "Reason recorded at ${latchFile}:" >&2
+        cat "${latchFile}" >&2
+        echo "Clear with: sudo rm ${latchFile}" >&2
+        exit 1
+      fi
+    ''}"
+  ];
+
+  systemd.tmpfiles.rules = [
+    "d ${stateDir} 0750 root root -"
+  ];
+
+  # Deliberately NOT added to homelab.postUpgradeCheck.services: that check
+  # asserts `systemctl is-active`, which a completed oneshot never satisfies.
+  # The detector's own liveness is covered by VpnLeakCheckStale in
+  # modules/grafana.nix, which is the right instrument for a periodic job.
+}

--- a/modules/vpn-killswitch.nix
+++ b/modules/vpn-killswitch.nix
@@ -48,7 +48,15 @@
 # "disabled until troubleshooting happens" means a human has to clear it.
 #
 #   Clear with:  sudo rm /var/lib/vpn-killswitch/tripped
-#                sudo systemctl start podman-gluetun
+#                sudo systemctl start podman-gluetun podman-qbittorrent \
+#                  podman-sabnzbd podman-radarr podman-sonarr \
+#                  podman-prowlarr podman-lidarr
+#
+# Starting podman-gluetun alone is NOT enough and this was verified the hard
+# way: Requires= propagates downward (stopping gluetun stops the consumers,
+# and restarting it restarts them) but it does not pull stopped consumers back
+# up when gluetun starts on its own. Measured 2026-08-02 — after a test trip,
+# `systemctl start podman-gluetun` brought back gluetun and nothing else.
 #
 # Metrics go to node_exporter's textfile collector (modules/monitoring.nix) and
 # are alerted on in the `vpn` rule group in modules/grafana.nix. The staleness
@@ -223,7 +231,7 @@ The arr stack has been STOPPED and latched off. It will not restart on reboot,
 deploy or auto-upgrade until the latch is cleared:
 
   sudo rm ${latchFile}
-  sudo systemctl start podman-gluetun" \
+  sudo systemctl start ${lib.concatStringsSep " " (lib.reverseList stackUnits)}" \
           "${ntfyUrl}" || true
       elif [ "$VERDICT_BAD" -eq 1 ]; then
         echo "Possible VPN leak (strike $STRIKES/2): $REASON" >&2


### PR DESCRIPTION
Two things in this homelab must not fail silently. Both had monitoring that could not see the failure that actually matters.

## VPN — the kill switch works; nothing could see it

Verified on the live host first (2026-08-02):

| check | result |
|---|---|
| `iptables -S OUTPUT` | policy `DROP`; ACCEPT only lo / conntrack / bridge / orthanc `/32` / WG UDP / tun0 |
| netns egress IP | `66.251.128.9` vs host `73.231.204.140` |
| `10.0.1.1` / `.8` / `.9` from netns | blocked |
| `10.0.1.10:8096` from netns | reachable (the intended `/32` exception) |
| netns `/etc/resolv.conf` | `127.0.0.1` — gluetun's own DoT resolver, so no DNS leak either |

So enforcement is sound. **Detection was the gap** — every existing check is structurally blind to the tunnel:

- Gatus `gluetun VPN` is a TCP connect to a control server listening on `:::8000` *inside the netns*, independent of tun0. It stays green with the VPN completely down. Its status routes would answer the real question but all return `Unauthorized` (gluetun now requires an auth config; `/var/lib/gluetun/auth/config.toml` is empty).
- The arr web-UI checks are reached over the podman bridge — equally tun0-independent.
- `UnitFailed` can't fire: gluetun retries internally and never exits.
- `gluetun-watchdog` notices only indirectly (NAT-PMP needs the tunnel), and its response is to **restart** — right for a dead tunnel, wrong for a leaking one.

### `modules/vpn-killswitch.nix`

A 5-minute check comparing the netns public IP against the host's and verifying gluetun's firewall shape. On **two consecutive** positive leak signals it stops the whole stack and latches it off via an `ExecStartPre` on `podman-gluetun`, so a reboot, deploy, or the 05:00 auto-upgrade cannot quietly bring it back.

Trips **only on positive evidence**. A netns that can't reach the internet is the kill switch *working* and never trips the latch; exec failures and timeouts are UNKNOWN, reported but never acted on.

## Ad blocking — entry counts are a lagging, partially blind indicator

`BlocklistEmpty` (#534) catches a collapsed list. It could not have caught the *second* bug found on 2026-08-01: **216,113 entries loaded while `pagead2.googlesyndication.com` resolved fine**, because bare entries match exact names only. Counting entries cannot detect that the entries don't match what you think.

- `BlocklistDownloadFailing` — fires on the first failed download. Would have fired 02:31 on 2026-07-31 instead of never.
- `BlocklistStale` — refreshes failing while the old list keeps serving; entry counts stay perfect and every other signal is silent.
- **Gatus ad-block canary** — asks each resolver for a known ad *subdomain* and asserts `0.0.0.0`. The only end-to-end test of whether blocking works, and the only one that would have caught the matching-semantics bug.

## Verification

Every control was tested in the direction that matters, not just for silence.

**Kill switch, live trip test** — injected a bogus egress rule (`192.0.2.1/32`, TEST-NET-1):

- strike 1 → detected, `vpn_firewall_intact 0`, stack left up (two-strike guard holds)
- strike 2 → stack **stopped**, latch written, ntfy priority 5 delivered
- `systemctl start podman-gluetun` while latched → **refused**, containers stayed down
- latch cleared → full recovery, `radarr` egress `45.83.137.9` ≠ host

**Firewall parser, 6 cases** — real ruleset passes; policy `ACCEPT`, widened `/24`, and `0.0.0.0/0` all caught; unreadable ruleset = UNKNOWN not violation; rotated WireGuard endpoint does *not* false-positive.

**Alert rules** — all 9 loaded `health=ok`; silent against live data while every selector demonstrably resolves; inverted thresholds match.

**Gatus canary** — ran the same Gatus version locally against a blocked and an unblocked domain to prove the condition isn't vacuous:

```
blocked-domain-expect-pass     [BODY] == 0.0.0.0                    -> True
unblocked-domain-expect-FAIL   [BODY] (104.16.133.229) == 0.0.0.0   -> False
```

## Notes

- One hypothesis I had was **wrong** and the test corrected it: I expected a bare `systemctl restart podman-gluetun` to orphan the dependents on a dead netns. It doesn't — `Requires=` propagation restarts them, measured twice. No fix needed.
- Propagation is one-way though: after a trip, starting `podman-gluetun` alone brings back gluetun and nothing else. The recovery instructions in the ntfy message, the alert annotation, and the module header all list the full unit set.
- Already deployed to pirateship, mirkwood and rivendell as part of the verification above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)