### PR TITLE
fix(homeassistant): declare the arr + qBittorrent components

### DIFF
--- a/modules/homeassistant.nix
+++ b/modules/homeassistant.nix
@@ -145,6 +145,22 @@
       "roborock"
       "twinkly"
       "wiim"
+
+      # Source 3 — integrations to be set up through the UI, listed BEFORE the
+      # config entry exists. Same failure as source 2, reached from the other
+      # direction: "Add Integration" returns
+      #   Config flow could not be loaded: {"message":"Invalid handler specified"}
+      # because the flow module cannot import its requirement. So a domain has
+      # to be added here and deployed *first*, then configured in the UI —
+      # source 1's jq will pick it up on the next regeneration.
+      #
+      # The media stack on pirateship. There is no prowlarr integration in HA
+      # core (nor bazarr), so those two are not omissions.
+      "lidarr"            # aiopyarr
+      "qbittorrent"       # qbittorrent-api
+      "radarr"            # aiopyarr
+      "sabnzbd"           # pysabnzbd
+      "sonarr"            # aiopyarr
     ];
 
     # HACS. It is a custom component, not a nixpkgs one — it lives in


### PR DESCRIPTION
"Add Integration" for qbittorrent, radarr, sonarr, lidarr and sabnzbd
fails with

  Config flow could not be loaded: {"message":"Invalid handler specified"}

because extraComponents did not list them, so their Python requirements
were never installed and the flow module cannot import:

  Error occurred loading flow for integration qbittorrent:
    No module named 'qbittorrentapi'
  Error occurred loading flow for integration radarr:
    No module named 'aiopyarr'

This is the third source of extraComponents entries and the only one that
must be populated *before* the UI is touched — sources 1 and 2 both
observe an integration that already exists. Documented as such inline.

prowlarr and bazarr have no HA core integration; jellyfin does but is not
set up, so it stays out until it is.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
