### PR TITLE
fix(dns): replace deleted HaGeZi blocklists with oisd + Phishing Army

### DIFF
--- a/Plan.md
+++ b/Plan.md
@@ -40,6 +40,29 @@ Shell function in dotfiles `home/common.nix`. deploy-rs config in `flake.nix` un
 
 - [ ] **Backup restore dry run**: test restoring from restic snapshots — both local (erebor) and offsite (R2). Validate paths, passwords, and snapshot contents are correct.
 
+### Power / Battery Resilience
+
+- [ ] **Low power mode — shed load while running on battery**. Prompted by the 2026-08-09 outage (~19:57, all hosts hard-cut). Design only, not yet implemented.
+
+  **What today actually does.** Nothing coordinated. `modules/nut.nix` runs NUT on rivendell *only*, as `upsmon` `type = "primary"`, and no other host runs a secondary. So rivendell sees `ONBATT`/`LOWBATT` and can shut itself down, while **mirkwood, pirateship and orthanc have no idea the power is out** — they run flat out until the battery dies and then take an unclean power cut. There is no graceful shutdown ordering and no load shedding anywhere in the repo.
+
+  **Measured baseline (2026-08-09, post-outage).** Tripp Lite SMC15002URM, `ups.load` 20% at idle; `battery.runtime` 1316s at 41% charge, so roughly **50 min at full charge and current load**. That is a lot of headroom *if* it is spent on the right things — and today it is spent equally on Jellyfin transcodes and on DNS.
+
+  **Goal.** On `ONBATT`, cut draw to the services that matter so the remaining runtime covers a much longer outage, then shut down cleanly and in the right order as the battery drains. Ride through short outages entirely.
+
+  Sketch of the tiers (to be argued out properly when this is picked up):
+  - **Tier 0 — never shed**: rivendell (DNS secondary, NUT itself, HA, ntfy, Caddy) and mirkwood (primary DNS). Losing DNS makes the whole house look broken.
+  - **Tier 1 — shed immediately on `ONBATT`**: the media stack. Pause/stop qBittorrent + SABnzbd transfers, stop Jellyfin transcodes, suspend the arr containers, stop recyclarr/music-sync timers. Pure discretionary load.
+  - **Tier 2 — shed early**: orthanc's non-essential workloads (Piped/Invidious, Minecraft servers, attic, CI runner). Orthanc is a 5950X/32GB box and is by far the biggest single draw on the UPS.
+  - **Tier 3 — graceful shutdown as the battery drains**: full `poweroff` for pirateship and orthanc well before `battery.charge.low` (currently 10%), leaving the DNS pair last.
+
+  Open questions to settle first:
+  - **Is orthanc even on the UPS?** It did not come back after this outage — needs its BIOS set to *Restore on AC Power Loss* regardless, or it will always need a physical press.
+  - Whether to drive this from **NUT secondaries** on every host (`upsmon` `type = "secondary"` pointed at `rivendell:3493`, with `NOTIFYFLAG`/`NOTIFYCMD` per tier) or from **Home Assistant** automations off the existing NUT integration. NUT secondaries are the more declarative fit and survive HA being down — which is exactly when this has to work. Prefer NUT; HA is the fallback for anything cosmetic.
+  - Hysteresis: what re-enables everything on `ONLINE`, and how to avoid flapping on a brownout. Needs a minimum-time-on-line before restoring.
+  - Recovery ordering on power return, which is the *other* half of this and is already known-broken: the 2026-08-09 restart raced DNS against NFS (`var-lib-media-music.mount` on rivendell and `navidrome` on pirateship both failed because `erebor.theshire.io` could not resolve yet). Fix the ordering as part of this work.
+  - Test plan must include **actually pulling the plug**, not just simulating with `upsmon -c fsd`. Per the standing verification note, a simulation that skips the constraint that matters proves nothing.
+
 ### NAS (erebor) — Remaining Work
 
 erebor is online (10G SFP+ at 10.0.1.22, 1G ethernet at 10.0.1.21 for management).

--- a/modules/dns.nix
+++ b/modules/dns.nix
@@ -79,16 +79,24 @@ upstreams = {
       };
 
       blocking = {
-        # SOURCE URLS — do not "modernise" these back to cdn.jsdelivr.net.
-        # jsDelivr refuses the whole hagezi repo with HTTP 403 ("Package size
-        # exceeded the configured limit of 150 MB"); the repo is ~157 MB and only
-        # grows, so that is permanent, not transient. It broke silently on
-        # 2026-07-31 — Blocky keeps serving with an EMPTY list rather than
-        # failing, so ads came back with no alert and no unhealthy unit.
-        # hagezi also restructured: the old `domains/` directory is gone. Its
-        # replacements come in two syntaxes holding the SAME entry set —
-        # `wildcard/<list>-onlydomains.txt` (bare `example.com`) and
-        # `wildcard/<list>.txt` (`*.example.com`). Use the `*.` one.
+        # SOURCE URLS — the HaGeZi lists that used to be here are GONE.
+        # On 2026-08-09 the entire `hagezi` GitHub ACCOUNT disappeared: both
+        # https://api.github.com/users/hagezi and every repo under it return
+        # 404, verified from two hosts while control repos (NixOS/nixpkgs)
+        # returned 200 on the same calls. This is not the old 403/restructure
+        # problem and it is not transient — there is no upstream left to retry.
+        # Symptom at the time: `blocky_denylist_cache_entries{group="ads"}` = 7
+        # (the inline entries below and nothing else) and `{group="malware"}` = 0.
+        # Do NOT "fix" this by pointing back at cdn.jsdelivr.net — jsDelivr was
+        # still serving a complete cached copy for a few hours after the origin
+        # died, which makes it look like a working source right up until the CDN
+        # revalidates against a dead origin and starts 404ing too.
+        #
+        # Replaced with oisd (independently hosted, not on GitHub, hourly
+        # rebuilds). Pick the `domainswild` variant, NOT `domainswild2`:
+        # oisd publishes the same entry set in both syntaxes, `domainswild` as
+        # `*.example.com` and `domainswild2` as bare `example.com`. This is the
+        # same trap hagezi had, for the same reason:
         #
         # WHY: a bare denylist entry in Blocky 0.34 matches that name ONLY.
         # It does NOT cover subdomains, despite what is widely assumed.
@@ -96,15 +104,19 @@ upstreams = {
         #   googlesyndication.com.          -> BLOCKED (ads: googlesyndication.com)
         #   pagead2.googlesyndication.com.  -> RESOLVED (142.251.219.2)
         # `*.example.com` blocks the apex AND every subdomain, which is what the
-        # hagezi entry set is collapsed to assume. Bare entries silently give a
-        # fraction of the intended coverage — the ad-serving hosts are almost
-        # always subdomains (pagead2., googleads.g., s0.), not the apex.
+        # oisd entry set is collapsed to assume — its own header says so:
+        # `"*.example.com" should block "example.com" and "subdomain.example.com"`.
+        # Bare entries silently give a fraction of the intended coverage — the
+        # ad-serving hosts are almost always subdomains (pagead2., googleads.g.,
+        # s0.), not the apex.
         denylists = {
-          # HaGeZi Pro — the main ads + trackers list. Aggressive coverage with
-          # a low false-positive rate; well maintained.
+          # oisd big — ads, trackers, telemetry, AND malware/phishing/ransomware/
+          # cryptojacking (~253k wildcard entries, rebuilt hourly). Tuned for
+          # "block, don't break", so the false-positive rate is low.
           ads = [
-            "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro.txt"
-            # HaGeZi Pro intentionally omits these Google ad apexes to avoid
+            "https://big.oisd.nl/domainswild"
+            # oisd, like HaGeZi Pro before it, intentionally omits these Google
+            # ad apexes to avoid
             # breaking Google services. We block them anyway for fuller ad
             # coverage (small risk: Google "sponsored" link / Shopping clicks).
             # Wildcarded for the reason above: googleads.g.doubleclick.net is
@@ -137,10 +149,25 @@ upstreams = {
               wpad.home.theshire.io
             ''
           ];
-          # HaGeZi Threat Intelligence Feeds — malware, phishing, cryptojacking,
-          # scam, and other actively-malicious domains.
+          # Phishing Army (extended) — phishing and fraud domains, ~156k entries.
+          #
+          # This group is now DEFENCE IN DEPTH, not the primary threat coverage:
+          # oisd big above already includes malware/phishing/ransomware/
+          # cryptojacking, and it does so in `*.` wildcard syntax. The group is
+          # kept for two reasons: it is a genuinely independent feed (different
+          # maintainer, different infrastructure, so one dead upstream no longer
+          # takes out threat blocking entirely), and ThreatBlocklistEmpty in
+          # modules/grafana.nix alerts per group — collapsing to a single group
+          # would silently retire that alert.
+          #
+          # CAVEAT: Phishing Army publishes BARE domains, so per the matching
+          # note above these entries match the exact name only, not subdomains.
+          # That is an accepted tradeoff here — phishing feeds list the exact
+          # observed FQDN rather than an apex to wildcard — but it is why this
+          # is the supplement and oisd is the primary. If a `*.`-syntax threat
+          # feed turns up, prefer it.
           malware = [
-            "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/tif.txt"
+            "https://phishing.army/download/phishing_army_blocklist_extended.txt"
           ];
         };
         # False-positive recovery. Add a domain here (one per line) to un-block
@@ -154,8 +181,8 @@ upstreams = {
         };
         clientGroupsBlock.default = [ "ads" "malware" ];
 
-        # The HaGeZi TIF list is very large (>1M domains); the default download
-        # timeout can truncate it mid-body on a slow CDN fetch. Give downloads
+        # The lists are large (~253k + ~156k entries); the default download
+        # timeout can truncate one mid-body on a slow fetch. Give downloads
         # more time and retries so lists always load complete.
         loading.downloads = {
           timeout  = "60s";

--- a/modules/grafana.nix
+++ b/modules/grafana.nix
@@ -178,17 +178,25 @@ let
             # for ~1.5 days; the only symptom was ads reappearing in iOS games.
             #
             # `blocky_denylist_cache_entries` is the one metric that tells the
-            # truth. Healthy is ~216k ads / ~2.16M malware; broken was 5 and 0
-            # (the 5 being the inline Google apexes, which parse without network).
-            # Thresholds sit far below normal but far above the broken values, so
-            # they tolerate hagezi resizing its lists without going quiet about a
-            # real failure.
+            # truth. Broken reads 7 and 0 (the 7 being the inline Google apexes
+            # and WPAD names, which parse without network) — which is exactly
+            # what both hosts showed on 2026-08-09 when the hagezi account was
+            # deleted outright. Thresholds sit far below normal but far above
+            # the broken values, so they tolerate a maintainer resizing a list
+            # without going quiet about a real failure.
+            #
+            # RETUNE THESE WHEN A SOURCE CHANGES. They are absolute counts tied
+            # to whatever modules/dns.nix currently points at; the numbers below
+            # are for oisd big (~253k) and Phishing Army extended (~156k). The
+            # old malware threshold was `< 1000000`, sized for hagezi TIF's
+            # ~2.16M entries — left unchanged it would have fired forever
+            # against the smaller replacement feed.
             #
             # Scoped to group="ads" rather than summed over all groups so a
             # collapse of one list cannot be masked by another's entries.
             #
             # 30m, not 5m: a deploy restarts Blocky and re-downloading plus
-            # parsing 2.1M domains is not instant. A genuine failure still fires
+            # parsing ~400k domains is not instant. A genuine failure still fires
             # long before the next 4h refresh could mask it.
             alert = "BlocklistEmpty";
             expr = ''blocky_denylist_cache_entries{group="ads"} < 100000'';
@@ -196,17 +204,17 @@ let
             labels.severity = "warning";
             annotations = {
               summary = "Blocky ad blocklist collapsed on {{ $labels.instance }}";
-              description = "{{ $labels.instance }} has only {{ $value }} entries in the 'ads' denylist (expected ~216k). Ad blocking is effectively off — check `journalctl -u blocky` for list download failures.";
+              description = "{{ $labels.instance }} has only {{ $value }} entries in the 'ads' denylist (expected ~253k). Ad blocking is effectively off — check `journalctl -u blocky` for list download failures.";
             };
           }
           {
             alert = "ThreatBlocklistEmpty";
-            expr = ''blocky_denylist_cache_entries{group="malware"} < 1000000'';
+            expr = ''blocky_denylist_cache_entries{group="malware"} < 75000'';
             "for" = "30m";
             labels.severity = "warning";
             annotations = {
               summary = "Blocky threat-intel blocklist collapsed on {{ $labels.instance }}";
-              description = "{{ $labels.instance }} has only {{ $value }} entries in the 'malware' denylist (expected ~2.16M). Malware/phishing blocking is effectively off — check `journalctl -u blocky` for list download failures.";
+              description = "{{ $labels.instance }} has only {{ $value }} entries in the 'malware' denylist (expected ~156k). The supplemental phishing feed is down — primary malware coverage still comes from oisd big in the 'ads' group, so check that alert too, then `journalctl -u blocky`.";
             };
           }
           {


### PR DESCRIPTION
The entire `hagezi` GitHub account was deleted on 2026-08-09 — the user
and every repo under it 404, verified from two hosts while control repos
returned 200 on the same calls. Both denylist groups lost their upstream,
so ad and malware blocking were serving empty: `denylist_cache_entries`
read 7 for `ads` (the inline entries only) and 0 for `malware`.

This was NOT caused by the power outage the same evening. The outage
buried the first real errors under transient `network is unreachable`
noise, but the retries that followed got a clean HTTP 404.

- ads     -> oisd big `domainswild` (~253k, hourly, `*.` wildcard syntax)
- malware -> Phishing Army extended (~156k) as an independent supplement;
             oisd big already covers malware/phishing/ransomware, so the
             group is now defence in depth and keeps ThreatBlocklistEmpty
             meaningful rather than being collapsed away.

Retunes both entry-count alerts in modules/grafana.nix. The malware
threshold was `< 1000000`, sized for HaGeZi TIF's ~2.16M entries; left
alone it would have fired permanently against the smaller feed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
