### PR TITLE
fix(backup): use /var/lib/private for DynamicUser state dirs

### DIFF
--- a/hosts/orthanc.nix
+++ b/hosts/orthanc.nix
@@ -212,6 +212,12 @@
     "/var/lib/minecraft"                  # Prominence II world + server files
     "/var/lib/minecraft-abyssal-ascent"   # Abyssal Ascent world + server files
     "/var/lib/jellyfin"   # library database, config, plugins (not cache — auto-regenerates)
-    "/var/lib/atticd"     # attic DB + NAR storage (GC retains last 2 weeks of entries)
+    # attic DB + NAR storage (GC retains last 2 weeks of entries).
+    # The /var/lib/private prefix is REQUIRED — atticd runs with
+    # DynamicUser=true, so /var/lib/atticd is only a symlink into
+    # /var/lib/private/atticd and restic archives a symlink as a symlink.
+    # This was "/var/lib/atticd" from 2026-04-03 to 2026-08-10 and every
+    # snapshot in that window holds a single 0-byte symlink and no attic data.
+    "/var/lib/private/atticd"
   ];
 }

--- a/hosts/rivendell.nix
+++ b/hosts/rivendell.nix
@@ -155,7 +155,16 @@
     "/var/lib/thread"
 
     "/var/lib/caddy"
-    "/var/lib/music-assistant"
+
+    # Music Assistant: library DB, provider config, and the streams/webserver
+    # publish_ip pin (see the comment in modules/music-assistant.nix). The
+    # /var/lib/private prefix is REQUIRED — services.music-assistant sets
+    # DynamicUser=true, exactly the case the matter-server note above warns
+    # about. This was "/var/lib/music-assistant" from 2026-03-28 to 2026-08-10
+    # and every snapshot in that window holds a single 0-byte symlink and no MA
+    # data at all. Verify after changing with:
+    #   restic ls <snap> | grep -c '^/var/lib/private/music-assistant'
+    "/var/lib/private/music-assistant"
   ];
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
music-assistant (rivendell) and atticd (orthanc) both run with
DynamicUser=true, so systemd keeps their real state directory under
/var/lib/private/<name> and leaves a symlink at the unprefixed path.
restic archives a symlink as a symlink, so both services were backing
up a single 0-byte link and none of their data.

Verified against the live repos — in rivendell's 2026-08-10 snapshot:

  Lrwxrwxrwx 0 0 0 /var/lib/music-assistant -> private/music-assistant

one entry, versus 144 for caddy and 3102 for homeassistant. orthanc's
current snapshot shows the same for /var/lib/atticd. The MA symlink is
dated 2026-03-28 and the atticd one 2026-04-03, so neither service has
ever had a usable backup.

This is exactly the failure the matter-server note in hosts/rivendell.nix
already warned about; that path dodged it only because matter-server is
still a container.

Adds ~78M (MA) and ~2.5G (atticd: 2.1G NAR storage + 72M DB) to the
nightly runs, both within the ~20G revisit threshold in modules/backup.nix.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
