### PR TITLE
fix(music-assistant): pin published stream IP off the IoT VLAN

### DIFF
--- a/modules/ma-publish-ip.py
+++ b/modules/ma-publish-ip.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Pin Music Assistant's published stream address into settings.json.
+
+Runs as ExecStartPre for music-assistant.service, before MA reads its config.
+
+WHY THIS EXISTS
+---------------
+MA's `publish_ip` (streams, :8097) and `base_url` (webserver, :8095) default to
+`ip_addresses[0]` -- the *first enumerated* interface address, evaluated live.
+rivendell has eth0 (10.0.1.9, LAN) and eth0.4 (10.0.12.2, IoT VLAN), and on a
+cold boot MA can start before eth0 finishes DHCP, so the static VLAN address
+sorts first. MA then advertises stream URLs on an interface no player can reach.
+
+That breaks exactly the *pull-based* players (WiiM/DLNA/Chromecast fetch an
+MA-advertised URL) and leaves *push-based* ones (AirPlay) working, with no error
+in the UI or the log -- MA has no feedback channel for "device could not fetch".
+Observed 2026-08-09: every WiiM hung silently in LinkPlay `status: "load"`.
+
+WHY NOT JUST SAVE IT VIA THE API
+--------------------------------
+Because that silently does nothing. `Config.to_raw`
+(music_assistant_models/config_entries.py:362) persists a value only
+
+    if x.value != x.default_value
+
+so saving the correct IP at a moment when the default *already* computed to the
+correct IP stores nothing at all -- and the next boot is free to race the other
+way. `Config.parse` on the other hand applies any stored value unconditionally,
+so writing the key straight into settings.json is what actually pins it.
+
+Rewriting on every start is deliberate: MA may strip the key again on its own
+next save (same to_raw rule), which is harmless within a boot but means the file
+cannot be treated as write-once.
+
+Never fails the unit -- a broken pin must not stop music from starting.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print(f"usage: {sys.argv[0]} <settings.json> <publish_ip> <base_url>", file=sys.stderr)
+        return 0
+
+    path, publish_ip, base_url = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    if os.path.exists(path):
+        try:
+            with open(path, encoding="utf-8") as fh:
+                settings = json.load(fh)
+        except (OSError, ValueError) as err:
+            # Corrupt or unreadable: leave it entirely alone. MA owns this file
+            # and recovers from settings.json.backup; clobbering it here would
+            # turn a bad publish IP into a lost configuration.
+            print(f"ma-publish-ip: cannot read {path} ({err}); leaving unchanged", file=sys.stderr)
+            return 0
+    else:
+        # First boot / fresh state dir. A bare core block is valid input for
+        # Config.parse; MA fills in everything else during onboarding.
+        settings = {}
+
+    if not isinstance(settings, dict):
+        print("ma-publish-ip: settings.json is not an object; leaving unchanged", file=sys.stderr)
+        return 0
+
+    core = settings.setdefault("core", {})
+    if not isinstance(core, dict):
+        print("ma-publish-ip: core is not an object; leaving unchanged", file=sys.stderr)
+        return 0
+
+    # {"domain": <name>, "values": {...}} is the on-disk shape MA writes.
+    wanted = {"streams": ("publish_ip", publish_ip), "webserver": ("base_url", base_url)}
+
+    changed = False
+    for domain, (key, value) in wanted.items():
+        entry = core.setdefault(domain, {"domain": domain, "values": {}})
+        if not isinstance(entry, dict):
+            print(f"ma-publish-ip: core.{domain} is not an object; skipping", file=sys.stderr)
+            continue
+        entry.setdefault("domain", domain)
+        values = entry.setdefault("values", {})
+        if not isinstance(values, dict):
+            print(f"ma-publish-ip: core.{domain}.values is not an object; skipping", file=sys.stderr)
+            continue
+        if values.get(key) != value:
+            values[key] = value
+            changed = True
+
+    if not changed:
+        print(f"ma-publish-ip: already pinned to {publish_ip}", file=sys.stderr)
+        return 0
+
+    # Atomic replace within the same directory, so a crash mid-write cannot
+    # leave MA with a truncated settings.json.
+    directory = os.path.dirname(path) or "."
+    try:
+        fd, tmp = tempfile.mkstemp(dir=directory, prefix=".settings.json.")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(settings, fh, indent=4)
+                fh.flush()
+                os.fsync(fh.fileno())
+            if os.path.exists(path):
+                os.chmod(tmp, os.stat(path).st_mode & 0o7777)
+            os.replace(tmp, path)
+        except BaseException:
+            os.unlink(tmp)
+            raise
+    except OSError as err:
+        print(f"ma-publish-ip: failed to write {path} ({err})", file=sys.stderr)
+        return 0
+
+    print(f"ma-publish-ip: pinned publish_ip={publish_ip} base_url={base_url}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/music-assistant.nix
+++ b/modules/music-assistant.nix
@@ -29,6 +29,12 @@
 
 { config, pkgs, lib, ... }:
 
+let
+  # rivendell's LAN address. MA must advertise this and never eth0.4's
+  # 10.0.12.2 (IoT VLAN) -- see the ExecStartPre block below.
+  publishIp = "10.0.1.9";
+  webPort   = 8095;
+in
 {
   services.music-assistant = {
     enable = true;
@@ -54,7 +60,30 @@
     providers = [ "airplay" "chromecast" "sendspin" "dlna" "sonos" "wiim" ];
   };
 
-  networking.firewall.allowedTCPPorts = [ 8095 8097 7000 8927 ];
+  # Pin the published stream address before MA reads its config.
+  #
+  # publish_ip (:8097) and base_url (:8095) default to ip_addresses[0] -- the
+  # first enumerated interface address, evaluated live. rivendell is multi-homed
+  # (eth0 = 10.0.1.9 LAN, eth0.4 = 10.0.12.2 IoT VLAN), and on the 2026-08-09
+  # cold boot MA came up before eth0 finished DHCP, so the static VLAN address
+  # sorted first. Every WiiM then hung silently in LinkPlay `status: "load"`
+  # fetching a URL it cannot route to, while AirPlay -- which MA pushes to
+  # rather than advertising a URL for -- kept working and masked the outage.
+  #
+  # Saving this through MA's own API does NOT pin it: Config.to_raw persists a
+  # value only when it differs from the current default, so writing the correct
+  # IP while the default already happens to be correct stores nothing. Config
+  # .parse applies stored values unconditionally, so the file is the pin.
+  #
+  # Confirm after a reboot with:
+  #   journalctl -u music-assistant | grep "Starting streamserver on"
+  systemd.services.music-assistant.serviceConfig.ExecStartPre = [
+    ("${pkgs.python3}/bin/python3 ${./ma-publish-ip.py} "
+      + "/var/lib/music-assistant/settings.json "
+      + "${publishIp} http://${publishIp}:${toString webPort}")
+  ];
+
+  networking.firewall.allowedTCPPorts = [ webPort 8097 7000 8927 ];
   networking.firewall.allowedUDPPorts = [ 1900 ];
 
   # DLNA/UPnP discovery: MA sends M-SEARCH to the multicast group


### PR DESCRIPTION
MA's publish_ip (streams, :8097) and base_url (webserver, :8095) default
to ip_addresses[0] -- the first enumerated interface address, evaluated
live. rivendell is multi-homed (eth0 = 10.0.1.9 LAN, eth0.4 = 10.0.12.2
IoT VLAN), and on the 2026-08-09 cold boot MA started before eth0
finished DHCP, so the static VLAN address sorted first.

Every WiiM then hung silently in LinkPlay `status: "load"` fetching a URL
it cannot route to. The failure is invisible from MA's side: it breaks
only the pull-based players (WiiM/DLNA/Chromecast fetch an advertised
URL) while push-based AirPlay keeps working, and MA has no feedback
channel for "the device could not fetch this".

Saving the correct value through MA's own API does not fix it.
Config.to_raw (music_assistant_models/config_entries.py:362) persists a
value only `if x.value != x.default_value`, so writing the right IP at a
moment when the default already computed to the right IP stores nothing
at all -- verified: settings.json had no core.streams key afterwards, and
the apparent fix was just the default racing the other way. Config.parse
applies stored values unconditionally, so the file is the actual pin.

ExecStartPre rewrites the key on every start rather than once, because MA
may strip it again on its own next save under the same to_raw rule.

The script never fails the unit -- corrupt or unreadable settings.json is
left strictly alone (MA owns it and recovers from settings.json.backup)
rather than risking a lost configuration to fix a publish IP.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
